### PR TITLE
Add "pure" annotation to `resolvePackageName`

### DIFF
--- a/registry/lib/packages.js
+++ b/registry/lib/packages.js
@@ -813,6 +813,7 @@ function resolvePackageLicenses(licenseFieldValue, where) {
   return licenseNodes
 }
 
+/*#__PURE__*/
 function resolvePackageName(purlObj, delimiter = '/') {
   const { name, namespace } = purlObj
   return `${namespace ? `${namespace}${delimiter}` : ''}${name}`


### PR DESCRIPTION
We'd like to import the `resolvePackageName` function, but unfortunately this can break frontend code (e.g. Webpack) because it ends up pulling in a bunch of unrelated code:

```
Module build failed: UnhandledSchemeError: Reading from "node:module" is not handled by plugins (Unhandled scheme).                                                                      
Webpack supports "data:" and "file:" URIs by default.                    
You may need an additional plugin to handle "node:" URIs.                                                                                                                            
[...]                                                                                
                                                                                                                                                                                         
Import trace for requested module:                                                                                                                                                       
node:module                                                                                                                                                                              
../../node_modules/is-core-module/index.js                                                                                                                                               
../../node_modules/@socketsecurity/registry/node_modules/normalize-package-data/lib/fixer.js                                                                                             
../../node_modules/@socketsecurity/registry/node_modules/normalize-package-data/lib/normalize.js                                                                                         
../../node_modules/@socketsecurity/registry/lib/packages.js                                                                                                                              
[...]
```

Adding a ["pure" annotation](https://webpack.js.org/guides/tree-shaking/#mark-a-function-call-as-side-effect-free) fixes this by instructing bundlers like Webpack and Rollup that the function has no side effects.

It may also be useful to add this annotation to other functions in this project.