### PR TITLE
Add `yoctocolors-cjs` to `browser`:`false`

### DIFF
--- a/registry/package.json
+++ b/registry/package.json
@@ -37,7 +37,8 @@
     "process": false,
     "tinyglobby": false,
     "validate-npm-package-name": false,
-    "which": false
+    "which": false,
+    "yoctocolors-cjs": false
   },
   "exports": {
     ".": {

--- a/registry/package.json
+++ b/registry/package.json
@@ -22,6 +22,7 @@
     "@npmcli/package-json": false,
     "@npmcli/promise-spawn": false,
     "@socketregistry/yocto-spinner": false,
+    "@socketregistry/yocto-spinner/index.cjs": false,
     "browserslist": false,
     "cacache": false,
     "console": false,

--- a/registry/package.json
+++ b/registry/package.json
@@ -21,6 +21,7 @@
     "@inquirer/select": false,
     "@npmcli/package-json": false,
     "@npmcli/promise-spawn": false,
+    "@socketregistry/yocto-spinner": false,
     "browserslist": false,
     "cacache": false,
     "console": false,


### PR DESCRIPTION
This seems to be another package causing issues for Webpack:

```
node:tty
Module build failed: UnhandledSchemeError: Reading from "node:tty" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
    at
[...]

Import trace for requested module:
node:tty
../../node_modules/yoctocolors-cjs/index.js
../../node_modules/@socketsecurity/registry/lib/logger.js
../../node_modules/@socketsecurity/registry/lib/spinner.js
../../node_modules/@socketsecurity/registry/lib/constants.js
../../node_modules/@socketsecurity/registry/lib/packages.js
[...]
```