### PR TITLE
Add space around icon for success/error/info/warn

### DIFF
--- a/registry/lib/logger.js
+++ b/registry/lib/logger.js
@@ -31,10 +31,10 @@ const LOG_SYMBOLS = /*@__PURE__*/ (() => {
       /*@__PURE__*/ require('../external/@socketregistry/is-unicode-supported')()
     const colors = getYoctocolors()
     Object.assign(target, {
-      fail: colors.red(supported ? '✖️' : '×'),
-      info: colors.blue(supported ? 'ℹ' : 'i'),
-      success: colors.green(supported ? '✔' : '√'),
-      warn: colors.yellow(supported ? '⚠' : '‼')
+      fail: colors.red(supported ? ' ✖️ ' : ' × '),
+      info: colors.blue(supported ? ' ℹ ' : ' i '),
+      success: colors.green(supported ? ' ✔ ' : ' √ '),
+      warn: colors.yellow(supported ? ' ⚠ ' : ' ‼ ')
     })
     Object.freeze(target)
     // The handler of a Proxy is mutable after proxy instantiation.


### PR DESCRIPTION
There's no spacing after (or before) the icons for the .success() .error() .warn() and .info() methods on the logger. That makes it look awkward.

![image](https://github.com/user-attachments/assets/b89d57c1-0dca-4273-825a-6b932241d60a)
vs
![image](https://github.com/user-attachments/assets/7f0850cf-4b7e-49b9-8f86-45ee41fbeef6)

This adds spaces before and after the icon. Feel free to offer a better solution if you have one.