### PR TITLE
Sync Claude Code version to 2.1.98

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@anthropic-ai/claude-code':
-      specifier: 2.1.92
-      version: 2.1.92
+      specifier: 2.1.98
+      version: 2.1.98
     '@babel/core':
       specifier: 7.28.4
       version: 7.28.4
@@ -278,7 +278,7 @@ importers:
     devDependencies:
       '@anthropic-ai/claude-code':
         specifier: 'catalog:'
-        version: 2.1.92
+        version: 2.1.98
       '@babel/core':
         specifier: 'catalog:'
         version: 7.28.4
@@ -894,8 +894,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@anthropic-ai/claude-code@2.1.92':
-    resolution: {integrity: sha512-mNGw/IK3+1yHsQBeKaNtdTPCrQDkUEuNTJtm3OBTXs4bBkUVdIgRme/34ZnbZkl2VMMYPoNaTvqX2qJZ9EdSxQ==}
+  '@anthropic-ai/claude-code@2.1.98':
+    resolution: {integrity: sha512-qecREauMWXHplkpjqsuDuUv4ww+NprMl71k9sMuLkZU7qwjLMkTPxRBjuKvZWWMrAPvZWdGZE9LljUTfCQ1lWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -3881,7 +3881,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
 
-  '@anthropic-ai/claude-code@2.1.92':
+  '@anthropic-ai/claude-code@2.1.98':
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 # Wait 7 days (10080 minutes) before installing newly published packages.
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - '@anthropic-ai/claude-code@2.1.92'
+  - '@anthropic-ai/claude-code@2.1.98'
   - '@socketaddon/*'
   - '@socketbin/*'
   - '@socketregistry/*'
@@ -14,7 +14,7 @@ packages:
   - scripts
 
 catalog:
-  '@anthropic-ai/claude-code': 2.1.92
+  '@anthropic-ai/claude-code': 2.1.98
   '@babel/core': 7.28.4
   '@babel/generator': 7.28.3
   '@babel/parser': 7.28.4


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/claude-code` from 2.1.92 to 2.1.98 in catalog and minimumReleaseAgeExclude

## Test plan

- [ ] CI passes with the updated dependency