### PR TITLE
fix: strip any host prefix from repository, not just github:

### DIFF
--- a/.claude/hooks/setup-security-tools/index.mts
+++ b/.claude/hooks/setup-security-tools/index.mts
@@ -127,7 +127,7 @@ async function setupZizmor(): Promise<boolean> {
     throw new Error(`Unsupported platform: ${platformKey}`)
   }
   const { asset, sha256: expectedSha } = platformEntry
-  const repo = ZIZMOR.repository?.replace(/^github:/, '') ?? ''
+  const repo = ZIZMOR.repository?.replace(/^[^:]+:/, '') ?? ''
   const url = `https://github.com/${repo}/releases/download/v${ZIZMOR.version}/${asset}`
 
   logger.log(`Downloading zizmor v${ZIZMOR.version} (${asset})...`)
@@ -184,7 +184,7 @@ async function setupSfw(apiKey: string | undefined): Promise<boolean> {
 
   // Checksum + asset.
   const { asset, sha256 } = platformEntry
-  const repo = sfwConfig.repository?.replace(/^github:/, '') ?? ''
+  const repo = sfwConfig.repository?.replace(/^[^:]+:/, '') ?? ''
   const url = `https://github.com/${repo}/releases/download/${sfwConfig.version}/${asset}`
   const binaryName = isEnterprise ? 'sfw' : 'sfw-free'
 

--- a/.claude/hooks/setup-security-tools/update.mts
+++ b/.claude/hooks/setup-security-tools/update.mts
@@ -146,7 +146,7 @@ async function updateZizmor(config: Config): Promise<UpdateResult> {
     return { tool, skipped: true, updated: false, reason: 'not in config' }
   }
 
-  const repo = toolConfig.repository ?? 'zizmorcore/zizmor'
+  const repo = toolConfig.repository?.replace(/^[^:]+:/, '') ?? 'zizmorcore/zizmor'
 
   let release: GhRelease
   try {
@@ -265,7 +265,7 @@ async function updateSfwTool(
     return { tool: toolName, skipped: true, updated: false, reason: 'not in config' }
   }
 
-  const repo = toolConfig.repository
+  const repo = toolConfig.repository?.replace(/^[^:]+:/, '')
   if (!repo) {
     return { tool: toolName, skipped: true, updated: false, reason: 'no repository' }
   }

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -151,7 +151,7 @@ async function downloadAndVerify(tool, config) {
       await rm(cachePath, { recursive: true, force: true })
     }
 
-    const repo = config.repository.replace(/^github:/, '')
+    const repo = config.repository.replace(/^[^:]+:/, '')
     const tmpDir = path.join(
       getCacheDir(),
       `.tmp-${tool}-${version}-${process.pid}`,


### PR DESCRIPTION
## Summary
- Repository values in `external-tools.json` use a `<host>:owner/repo` prefix convention (e.g. `github:zizmorcore/zizmor`)
- Changed all `.replace(/^github:/, '')` calls to `.replace(/^[^:]+:/, '')` to handle any host prefix generically
- Added missing prefix stripping in `update.mts` (was passing raw `github:` prefixed values to GitHub API calls)

## Test plan
- [x] Lint passes
- [x] Tests pass (2184 tests)
- [x] Verified no hardcoded `github:` replace patterns remain