### PR TITLE
fix: resolve quality scan issues

### DIFF
--- a/scripts/npm/make-npm-override.mjs
+++ b/scripts/npm/make-npm-override.mjs
@@ -96,7 +96,7 @@ const { positionals: cliPositionals, values: cliArgs } = parseArgs({
   strict: false,
 })
 
-const bcaKeysMap = new Map()
+const bcaKeysMap = new WeakMap()
 
 const esShimChoices = [
   {

--- a/scripts/npm/release-npm-packages.mjs
+++ b/scripts/npm/release-npm-packages.mjs
@@ -267,8 +267,7 @@ async function hasPackageChanged(pkg, manifest_, options) {
         const message = `${pkg.name}: File '${file}' exists in published package but not locally`
         state?.warnings.push(message)
         changed = true
-      }
-      if (remoteHash !== localHash) {
+      } else if (remoteHash !== localHash) {
         const message = `${pkg.name}: File '${file}' content differs`
         state?.changes.push(message)
         changed = true

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -183,8 +183,8 @@ async function main() {
     logger.log('  Publish Runner')
     logger.log('────────────────────────────────────────────────────────────')
 
-    // Validate build artifacts if not skipping
-    if (values['skip-build']) {
+    // Validate build artifacts if not skipping.
+    if (!values['skip-build']) {
       const artifactsExist = await validateBuildArtifacts()
       if (!artifactsExist && !values.force) {
         logger.error('Build artifacts missing - run pnpm build first')


### PR DESCRIPTION
## Summary

- Fix inverted `skip-build` condition in `publish.mjs` — artifacts were validated only when skipping build, not when running it
- Fix duplicate file diff reporting in `release-npm-packages.mjs` — missing files reported as both "missing" and "differs" (added `else`)
- Change `bcaKeysMap` from `Map` to `WeakMap` in `make-npm-override.mjs` to allow GC of browser compat data objects

## Test plan

- [x] All 2184 tests pass
- [x] Lint and typecheck pass
- [x] Build succeeds