### PR TITLE
fix: add set -euo pipefail to provenance workflow shell steps

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -137,6 +137,7 @@ jobs:
         env:
           SETUP_SCRIPT: ${{ inputs.setup-script }}
         run: |
+          set -euo pipefail
           # Trim whitespace
           SETUP_SCRIPT=$(echo "$SETUP_SCRIPT" | xargs)
 
@@ -171,6 +172,7 @@ jobs:
           FORCE_REGISTRY: ${{ inputs.force-registry }}
           SKIP_NPM_PACKAGES: ${{ inputs.skip-npm-packages }}
         run: |
+          set -euo pipefail
           # Trim whitespace
           PUBLISH_SCRIPT=$(echo "$PUBLISH_SCRIPT" | xargs)
 
@@ -210,6 +212,7 @@ jobs:
         env:
           ACCESS_SCRIPT: ${{ inputs.access-script }}
         run: |
+          set -euo pipefail
           # Trim whitespace
           ACCESS_SCRIPT=$(echo "$ACCESS_SCRIPT" | xargs)
 


### PR DESCRIPTION
## Summary

- Add `set -euo pipefail` to 3 shell steps in `provenance.yml`: setup-script, publish-script, and access-script
- Without this, failures in these steps are silently ignored and publishing continues with broken state

## Cascade

This is a **Layer 3** change. After merge:
1. Layer 4 PR needed to update `_local-not-for-reuse-provenance.yml` (+ ci.yml, weekly-update) SHA pins
2. External repos that reference `provenance.yml` need the propagation SHA

## Test plan

- [x] YAML syntax valid
- [x] No other refs changed