### PR TITLE
fix(config): align .npmrc and pnpm-workspace.yaml for pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # npm v11+ settings (not pnpm — pnpm v11 only reads auth/registry from .npmrc).
+ignore-scripts=true
 min-release-age=7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,3 @@
-# Migrated from .npmrc (pnpm v11 only reads auth/registry from .npmrc).
-ignoreScripts: true
-linkWorkspacePackages: false
 trustPolicy: no-downgrade
 
 # Wait 7 days (10080 minutes) before installing newly published packages.


### PR DESCRIPTION
## Summary
- Remove `ignoreScripts: true` from `pnpm-workspace.yaml` (was blocking project `prepare` scripts)
- Remove `linkWorkspacePackages` (removed in pnpm v11)
- Add `ignore-scripts=true` to `.npmrc` for npm compatibility
- Rely on pnpm v11 `strictDepBuilds` (default true) + `allowBuilds` for dep script control

## Test plan
- [x] Verify `pnpm install` works locally
- [ ] Verify CI passes