### PR TITLE
feat(skills): xport lock-step family + weekly-update reusable workflow

### DIFF
--- a/.claude/skills/updating-upstream/SKILL.md
+++ b/.claude/skills/updating-upstream/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: updating-upstream
+description: Bumps git submodules declared in `.gitmodules` to their latest stable upstream tag, for submodules NOT managed by an xport `version-pin` row. Reads the `# <name>-<version>` comment above each submodule as the current pin, finds the latest stable tag (excluding pre-releases), checks out, updates the comment, commits atomically. Invoked by the `updating` umbrella skill; can also be invoked standalone.
+user-invocable: true
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+# updating-upstream
+
+<task>
+Bump every git submodule in `.gitmodules` that is NOT managed by an xport `version-pin` row, to its latest stable upstream tag. One atomic commit per submodule. Exits cleanly when the repo has no `.gitmodules` or when all submodules are owned by xport.
+</task>
+
+<context>
+`.gitmodules` is the source of truth for which submodules exist. Each block may carry a version comment on the line immediately above:
+
+```
+# yoga-3.2.1
+[submodule "packages/yoga/upstream/yoga"]
+  path = packages/yoga/upstream/yoga
+  url = https://github.com/facebook/yoga.git
+  ignore = dirty
+```
+
+**Division of labor with xport:**
+- If `xport.json` exists AND a submodule's path matches an `upstreams[<alias>].submodule` referenced by a `version-pin` row, it's owned by `updating-xport`. Skip it here.
+- All other submodules are owned by this skill.
+
+**Tag scheme detection** (in order of preference):
+1. Existing `# <prefix>-<version>` comment — use that prefix to find the next tag
+2. `v1.2.3` (v-prefixed semver)
+3. `1.2.3` (bare semver)
+4. Underscore style: `curl-8_19_0`, `liburing-2.14`
+</context>
+
+<constraints>
+**Requirements:**
+- Clean tree at start
+- Conventional commit format: `chore(deps): bump <name> to <tag>`
+- Update the `# <name>-<version>` comment line in `.gitmodules` (use Edit tool, not sed)
+- Exclude pre-releases: `-rc`, `-alpha`, `-beta`, `-dev`, `-snapshot`, `-nightly`, `-preview`
+
+**Forbidden:**
+- Never bump a submodule managed by xport (defer to `updating-xport`)
+- Never bump to a pre-release tag
+- Never use `npx`, `pnpm dlx`, `yarn dlx`
+- Never use sed to edit YAML/JSON (per CLAUDE.md) — use Edit tool
+
+**CI mode** (`CI=true` / `GITHUB_ACTIONS`): skip per-bump test validation.
+**Interactive mode**: `pnpm test` after each bump; roll back on test failure.
+</constraints>
+
+<instructions>
+
+## Phase 1 — Pre-flight
+
+```bash
+test -f .gitmodules || { echo "no .gitmodules; skill n/a"; exit 0; }
+git status --porcelain | grep -v '^??' && { echo "dirty tree; aborting"; exit 1; } || true
+[ "$CI" = "true" ] || [ -n "$GITHUB_ACTIONS" ] && CI_MODE=true || CI_MODE=false
+```
+
+## Phase 2 — Discover submodules
+
+List every submodule path:
+
+```bash
+git config --file .gitmodules --get-regexp path | awk '{print $2}'
+```
+
+For each path, check xport ownership:
+
+```bash
+if [ -f xport.json ]; then
+  OWNED=$(jq --arg p "$SM_PATH" \
+    '[.rows[] | select(.kind=="version-pin") | .upstream] as $pinned
+     | .upstreams | to_entries
+     | map(select(.key as $k | $pinned | index($k)))
+     | map(select(.value.submodule == $p)) | length' xport.json)
+  [ "$OWNED" -gt 0 ] && { echo "skipping $SM_PATH (owned by xport)"; continue; }
+fi
+```
+
+## Phase 3 — Bump each unowned submodule
+
+For each:
+
+**3a. Read current version comment**
+
+The comment lives directly above `[submodule "..."]` in `.gitmodules`:
+
+```bash
+LINE_NUM=$(grep -n "^\[submodule \"$SM_NAME\"\]" .gitmodules | cut -d: -f1)
+COMMENT_LINE=$(sed -n "$((LINE_NUM - 1))p" .gitmodules)
+# Parse: "# yoga-3.2.1" → PREFIX=yoga, OLD_VERSION=3.2.1
+```
+
+If no comment: use `git describe --tags` from the submodule's current HEAD as the baseline.
+
+**3b. Find latest stable tag**
+
+```bash
+cd "$SM_PATH"
+git fetch origin --tags --quiet
+OLD_SHA=$(git rev-parse HEAD)
+
+# Try each pattern until a match is found:
+LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+[ -z "$LATEST" ] && LATEST=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+[ -z "$LATEST" ] && [ -n "$PREFIX" ] && LATEST=$(git tag --sort=-v:refname | grep -E "^${PREFIX}-[0-9]+\.[0-9]+\.[0-9]+$" | head -1)
+[ -z "$LATEST" ] && [ -n "$PREFIX" ] && LATEST=$(git tag --sort=-v:refname | grep -E "^${PREFIX}_[0-9]+_[0-9]+_[0-9]+$" | head -1)
+```
+
+No match: skip this submodule with a log note.
+
+**3c. Check out + update**
+
+```bash
+NEW_SHA=$(git rev-parse "$LATEST")
+[ "$OLD_SHA" = "$NEW_SHA" ] && { cd -; continue; }
+git checkout "$LATEST" --quiet
+cd -
+```
+
+**3d. Update `.gitmodules` comment**
+
+Use Edit tool to replace the comment line. If there was no prior comment, Edit to add one above the `[submodule "..."]` header.
+
+**3e. Validate + commit**
+
+```bash
+if [ "$CI_MODE" = "false" ]; then
+  pnpm test || {
+    echo "tests failed after bump of $SM_NAME; rolling back"
+    git checkout .gitmodules "$SM_PATH"
+    continue
+  }
+fi
+
+git add .gitmodules "$SM_PATH"
+git commit -m "chore(deps): bump $SM_NAME to $LATEST"
+```
+
+## Phase 4 — Report
+
+```
+## updating-upstream report
+
+**Bumped:** <N> submodule(s)
+<list with OLD_TAG → NEW_TAG>
+
+**Skipped (managed by xport):** <M> submodule(s)
+<list>
+
+**Skipped (no stable tag / already latest):** <K> submodule(s)
+<list>
+```
+
+Emit HANDOFF block per `_shared/report-format.md`:
+
+```
+=== HANDOFF: updating-upstream ===
+Status: {pass|fail}
+Findings: {bumped: N, skipped_xport: M, skipped_other: K}
+Summary: {one-line description}
+=== END HANDOFF ===
+```
+
+</instructions>
+
+## Success Criteria
+
+- Every non-xport submodule bumped to latest stable (or skipped with explicit reason)
+- One atomic commit per bumped submodule
+- `.gitmodules` version comments synchronized
+- No pre-release tags introduced
+- `git submodule status` clean (all prefixed with space) at end
+
+## When to use
+
+- Invoked by the `updating` umbrella skill (weekly-update workflow)
+- Standalone: `/updating-upstream` for a submodule-only sync

--- a/.claude/skills/updating-workflows/reference.md
+++ b/.claude/skills/updating-workflows/reference.md
@@ -30,19 +30,20 @@ Layer 2b — setup-and-install (references Layer 1 + 2a):
 Layer 3 — Shared reusable workflows (reference Layer 2):
   ci.yml                   -> refs: setup-and-install, run-script
   provenance.yml           -> refs: setup-and-install
+  weekly-update.yml        -> refs: setup-and-install, setup-git-signing, cleanup-git-signing
 
 Layer 4 — _local workflows (reference Layer 3, not reused externally):
-  _local-not-for-reuse-ci.yml         -> refs: ci.yml, setup-and-install, cache-npm-packages
-  _local-not-for-reuse-provenance.yml -> refs: provenance.yml
-  _local-not-for-reuse-weekly-update  -> refs: setup-and-install, setup-git-signing, cleanup-git-signing
+  _local-not-for-reuse-ci.yml             -> refs: ci.yml, setup-and-install, cache-npm-packages
+  _local-not-for-reuse-provenance.yml     -> refs: provenance.yml
+  _local-not-for-reuse-weekly-update.yml  -> refs: weekly-update.yml (via uses) OR setup-and-install directly
 ```
 
 ---
 
 ## Propagation SHA
 
-The **propagation SHA** is the Layer 3 merge SHA — the one where `ci.yml` and
-`provenance.yml` were updated.
+The **propagation SHA** is the Layer 3 merge SHA — the one where `ci.yml`,
+`provenance.yml`, or `weekly-update.yml` were updated.
 
 - Layer 4 (`_local-not-for-reuse-*`) pins to the propagation SHA
 - External repos pin to the propagation SHA
@@ -81,6 +82,7 @@ All pin to the propagation SHA (Layer 3 merge SHA):
 |------|--------|
 | socket-btm | Push directly to main |
 | sdxgen | Push directly to main (local checkout at `../socket-sdxgen/`) |
+| stuie | Push directly to main (local checkout at `../socket-tui/`) |
 | ultrathink | Push directly to main |
 | socket-cli | Create PR |
 | socket-lib | Create PR |

--- a/.claude/skills/updating-xport/SKILL.md
+++ b/.claude/skills/updating-xport/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: updating-xport
+description: Acts on `xport.json` drift for repos that carry the xport lock-step manifest. Reads `pnpm run xport --json`, then for each row acts per-kind — auto-bump `version-pin` rows (low-risk mechanical updates), advisory-only for `file-fork` / `feature-parity` / `spec-conformance` / `lang-parity` (upstream semantics need human judgment). Invoked by the `updating` umbrella skill; can also be invoked standalone.
+user-invocable: true
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+# updating-xport
+
+<task>
+Act on drift findings in `xport.json`. Auto-apply mechanical version-pin bumps; surface everything else as advisory notes for human review. Commit each actioned row as its own atomic commit so the PR reviewer can accept/reject per-row.
+</task>
+
+<context>
+**xport** is a cross-project lock-step manifest. Not every repo has one; this skill exits cleanly when `xport.json` is absent. See `xport.schema.json` (deployed via `socket-repo-template/sync-scaffolding.mjs`) for the five row kinds.
+
+The harness at `scripts/xport.mts` emits JSON reports with `severity ∈ {ok, drift, error}` per row. This skill consumes that JSON.
+
+**Per-kind action policy:**
+
+| Kind | Drift signal | Action |
+|------|--------------|--------|
+| `version-pin` | Upstream commits on default ref since pinned SHA | **Auto-bump** per `upgrade_policy`: `track-latest` → advance to latest stable tag; `major-gate` → advance patch/minor only; `locked` → advisory only |
+| `file-fork` | Upstream file changed since `forked_at_sha` | **Advisory** — note in PR body; do NOT auto-merge (forks carry local deltas that need human review) |
+| `feature-parity` | Parity score below `criticality/10` floor | **Advisory** — note in PR body; human decides implement vs downgrade criticality |
+| `spec-conformance` | Spec submodule moved | **Advisory** — note in PR body; human decides whether to bump `spec_version` |
+| `lang-parity` | Port divergence / `rejected` anti-pattern reintroduced | **Advisory** — note in PR body; humans fix the port or update the manifest |
+
+The common rule: **version-pin is mechanical** (safe to auto-apply with `track-latest`/`major-gate` policies); everything else is **advisory** (upstream semantics and local deltas matter, humans decide).
+</context>
+
+<constraints>
+**Requirements:**
+- Start with clean working directory (check via `git status --porcelain`)
+- Run from repo root
+- Exit 0 cleanly if `xport.json` is absent (the repo doesn't use xport)
+- Conventional commit format: `chore(deps): bump <upstream> to <tag>`
+- Update `.gitmodules` version comments when submodule tags change (pattern: `# <name>-<version>` on the line above the submodule block)
+- Target stable releases only (filter `-rc`, `-alpha`, `-beta`, `-dev`, `-snapshot`, `-nightly`, `-preview`)
+
+**Forbidden:**
+- Never auto-edit `file-fork`, `feature-parity`, `spec-conformance`, or `lang-parity` rows' tracked state
+- Never bump a `locked` version-pin without human approval
+- Never skip the tag-stability filter
+- Never use `npx`, `pnpm dlx`, `yarn dlx` — use `pnpm exec` or `pnpm run`
+
+**CI mode** (`CI=true` or `GITHUB_ACTIONS`): skip per-row test validation (workflow validates at the end); emit advisory summary to `$GITHUB_OUTPUT` when present.
+
+**Interactive mode** (default): validate each auto-bump with `pnpm test` before committing the next.
+</constraints>
+
+<instructions>
+
+## Phase 1 — Pre-flight
+
+```bash
+test -f xport.json || { echo "no xport.json; skill n/a"; exit 0; }
+test -f xport.schema.json || { echo "xport.schema.json missing — malformed scaffolding"; exit 1; }
+test -f scripts/xport.mts || { echo "scripts/xport.mts missing — malformed scaffolding"; exit 1; }
+
+git status --porcelain | grep -v '^??' && { echo "dirty tree; aborting"; exit 1; } || true
+
+[ "$CI" = "true" ] || [ -n "$GITHUB_ACTIONS" ] && CI_MODE=true || CI_MODE=false
+```
+
+## Phase 2 — Collect drift
+
+```bash
+pnpm run xport --json > /tmp/xport-report.json
+```
+
+Parse `reports[]` from the JSON. Split into:
+
+- **auto** — rows where `severity == "drift"` AND `kind == "version-pin"` AND `upgrade_policy` ∈ `{ "track-latest", "major-gate" }`
+- **advisory** — everything else with `severity != "ok"`
+
+If both lists empty: exit 0 with "no xport drift".
+
+## Phase 3 — Auto-bump version-pin rows
+
+For each row in **auto** list, in manifest declaration order:
+
+**3a. Resolve the upstream submodule + fetch tags**
+
+```bash
+SUBMODULE=$(jq -r --arg a "$UPSTREAM_ALIAS" '.upstreams[$a].submodule' xport.json)
+cd "$SUBMODULE"
+git fetch origin --tags --quiet
+OLD_SHA=$(git rev-parse HEAD)
+```
+
+**3b. Find the target tag**
+
+Examine existing `pinned_tag` to identify the tag scheme, then match:
+
+- `v1.2.3` (v-prefixed semver)
+- `1.2.3` (bare semver)
+- `<prefix>-1.2.3` (project-prefixed)
+- `<prefix>_1_2_3` (underscore style; curl, liburing)
+
+For `major-gate` policy: parse major version from `LATEST` vs current `pinned_tag`. If majors differ, skip — add to advisory with note "major bump needs human review".
+
+**3c. Check out + capture new SHA**
+
+```bash
+NEW_SHA_FOR_CHECK=$(git rev-parse "$LATEST")
+[ "$OLD_SHA" = "$NEW_SHA_FOR_CHECK" ] && { cd -; continue; }
+git checkout "$LATEST" --quiet
+NEW_SHA=$(git rev-parse HEAD)
+cd -
+```
+
+**3d. Update `xport.json` + `.gitmodules`**
+
+Use `jq` for structured edit:
+
+```bash
+jq --arg id "$ROW_ID" --arg sha "$NEW_SHA" --arg tag "$LATEST" \
+  '(.rows[] | select(.id == $id) | .pinned_sha) = $sha
+   | (.rows[] | select(.id == $id) | .pinned_tag) = $tag' \
+  xport.json > xport.json.tmp && mv xport.json.tmp xport.json
+```
+
+Update `.gitmodules` version comment via Edit tool (NOT sed per CLAUDE.md) — replace `# <prefix>-<old>` with `# <prefix>-<new>` on the comment line above the submodule block.
+
+**3e. Validate + commit**
+
+```bash
+# Confirm xport harness accepts the new state
+pnpm run xport --json > /tmp/xport-post.json
+jq --arg id "$ROW_ID" '.reports[] | select(.id == $id) | .severity' /tmp/xport-post.json
+# expect "ok"
+
+if [ "$CI_MODE" = "false" ]; then
+  pnpm test || {
+    echo "tests failed; rolling back $ROW_ID"
+    git checkout xport.json .gitmodules "$SUBMODULE"
+    continue
+  }
+fi
+
+git add xport.json .gitmodules "$SUBMODULE"
+git commit -m "chore(deps): bump $UPSTREAM_ALIAS to $LATEST"
+```
+
+Record bumped row in summary accumulator.
+
+## Phase 4 — Compose advisory notes
+
+For each row in **advisory**, accumulate a markdown line:
+
+```
+- **file-fork** `<id>`: `<local>` — <N> upstream commit(s) since <forked_at_sha[0:12]>. Review diff, cherry-pick if applicable, bump forked_at_sha.
+- **feature-parity** `<id>`: parity score <score> below floor <floor>. Implement or downgrade criticality with reason.
+- **spec-conformance** `<id>`: upstream spec repo moved. Review for breaking changes before bumping spec_version.
+- **lang-parity** `<id>`: <details from messages[]>.
+- **version-pin** `<id>`: major bump to <LATEST> — policy=major-gate requires human review.
+- **version-pin** `<id>`: upgrade_policy=locked — skipped.
+```
+
+## Phase 5 — Report + emit
+
+Final human-readable report to stdout:
+
+```
+## updating-xport report
+
+**Auto-bumped:** <N> row(s)
+<list>
+
+**Advisory (human review):** <M> row(s)
+<list>
+```
+
+In CI mode, emit the advisory block to `$GITHUB_OUTPUT` (base64-encoded) under key `xport-advisory` so the weekly-update workflow can include it in the PR body:
+
+```bash
+if [ -n "$GITHUB_OUTPUT" ]; then
+  echo "xport-advisory=$(printf '%s' "$ADVISORY" | base64 | tr -d '\n')" >> "$GITHUB_OUTPUT"
+fi
+```
+
+Emit a HANDOFF block per `_shared/report-format.md`:
+
+```
+=== HANDOFF: updating-xport ===
+Status: {pass|fail}
+Findings: {auto_bumped: N, advisory: M}
+Summary: {one-line description}
+=== END HANDOFF ===
+```
+
+</instructions>
+
+## Success Criteria
+
+- All actionable `version-pin` rows bumped atomically (one commit per row)
+- Advisory rows collected for PR body / workflow output
+- No edits to non-version-pin row state
+- `pnpm run xport` exits 0 or 2 at end (never 1 — no schema errors introduced)
+- `.gitmodules` version comments synchronized with `pinned_tag`
+
+## Commands
+
+- `pnpm run xport --json` — drift report (consumed by this skill)
+- `jq` — parse + edit `xport.json` (structured JSON edits)
+- `git submodule status` — verify submodule state after bumps
+
+## When to use
+
+- Invoked by the `updating` umbrella skill (weekly-update workflow)
+- Standalone: `/updating-xport` when syncing just the xport manifest
+- After manual submodule bumps, to refresh `xport.json` metadata

--- a/.claude/skills/updating/SKILL.md
+++ b/.claude/skills/updating/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: updating
-description: Updates all npm dependencies and workflow SHA pins. Triggers when user asks to "update dependencies", "update packages", "update everything", or prepare for a release.
+description: Umbrella update skill. Runs `pnpm run update` (npm), then delegates to `updating-xport` (if `xport.json` exists), `updating-upstream` (if `.gitmodules` exists), and `updating-workflows` (if SHA pins are stale). Triggers when user asks to "update dependencies", "update packages", "update everything", or prepare for a release.
 user-invocable: true
-allowed-tools: Bash, Read, Grep, Glob, Edit
+allowed-tools: Skill, Bash, Read, Grep, Glob, Edit
 ---
 
 # updating
@@ -14,11 +14,15 @@ SHA pins, and ensures all builds and tests pass.
 
 <context>
 **What is this?**
-This skill updates npm packages and checks workflow SHA pins.
+The umbrella update skill. Runs `pnpm run update` for npm deps, then delegates to sub-skills based on what the repo has:
 
 **Update Targets:**
-- npm packages via `pnpm run update`
-- Workflow SHA pins via the `updating-workflows` skill (when stale)
+- **npm packages** — via `pnpm run update` (every Socket repo has this script)
+- **xport-managed upstreams** — via the `updating-xport` skill if `xport.json` exists (manifest-managed submodules + advisory drift)
+- **Other submodules** — via the `updating-upstream` skill if `.gitmodules` has submodules not claimed by xport
+- **Workflow SHA pins** — via the `updating-workflows` skill (when stale)
+
+Sub-skills are invoked only when applicable — this umbrella reads repo state (presence of `xport.json`, `.gitmodules`) to discover what to run.
 </context>
 
 <constraints>
@@ -77,6 +81,42 @@ fi
 
 ---
 
+### Phase 2.5: xport-managed upstreams (if applicable)
+
+Update queue: advance `current_phase` in `.claude/ops/queue.yaml`
+
+If `xport.json` exists at repo root, invoke the `updating-xport` skill:
+
+```
+<Skill tool invocation>
+skill: updating-xport
+</Skill tool invocation>
+```
+
+The sub-skill auto-bumps `version-pin` rows per their `upgrade_policy` and emits advisory notes for `file-fork` / `feature-parity` / `spec-conformance` / `lang-parity` findings. Capture its HANDOFF block for the final summary.
+
+If `xport.json` does NOT exist, skip this phase.
+
+---
+
+### Phase 2.75: Remaining submodules (if applicable)
+
+Update queue: advance `current_phase` in `.claude/ops/queue.yaml`
+
+If `.gitmodules` exists, invoke the `updating-upstream` skill:
+
+```
+<Skill tool invocation>
+skill: updating-upstream
+</Skill tool invocation>
+```
+
+The sub-skill automatically skips submodules claimed by xport's `version-pin` rows. It bumps the rest to their latest stable tags.
+
+If no `.gitmodules`, skip this phase.
+
+---
+
 ### Phase 3: Check Workflow SHA Pins
 
 Update queue: advance `current_phase` in `.claude/ops/queue.yaml`
@@ -127,6 +167,8 @@ Generate update report:
 | Category | Status |
 |----------|--------|
 | npm packages | Updated/Up to date |
+| xport upstreams | N version-pin rows bumped, M advisory (or n/a if no `xport.json`) |
+| Other submodules | K bumped (or n/a if no `.gitmodules`) |
 | Workflow SHA pins | Up to date/Stale (run /update-workflows) |
 
 ### Commits Created:

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -184,8 +184,10 @@ jobs:
       - name: Initialize submodules
         if: inputs.checkout-submodules != 'false'
         shell: bash
+        env:
+          SUBMODULES: ${{ inputs.checkout-submodules }}
         run: |
-          if [ "${{ inputs.checkout-submodules }}" = "recursive" ]; then
+          if [ "$SUBMODULES" = "recursive" ]; then
             git submodule update --init --recursive
           else
             git submodule update --init
@@ -333,11 +335,12 @@ jobs:
         if: steps.final.outputs.success == 'true'
         env:
           VALIDATE_PATTERNS: ${{ inputs.validate-file-patterns }}
+          PR_BASE: ${{ inputs.pr-base }}
         run: |
           UNEXPECTED=""
           # Build a case-glob test from pipe-separated patterns
           PATTERNS=$(echo "$VALIDATE_PATTERNS" | tr '|' ' ')
-          for file in $(git diff --name-only origin/${{ inputs.pr-base }}..HEAD); do
+          for file in $(git diff --name-only "origin/${PR_BASE}..HEAD"); do
             MATCH=false
             for pat in $PATTERNS; do
               case "$file" in
@@ -353,8 +356,10 @@ jobs:
 
       - name: Check for changes
         id: changes
+        env:
+          PR_BASE: ${{ inputs.pr-base }}
         run: |
-          if [ "$(git rev-list --count HEAD ^origin/${{ inputs.pr-base }})" -gt 0 ]; then
+          if [ "$(git rev-list --count HEAD "^origin/${PR_BASE}")" -gt 0 ]; then
             echo "has-changes=true" >> $GITHUB_OUTPUT
           else
             echo "has-changes=false" >> $GITHUB_OUTPUT
@@ -406,11 +411,12 @@ jobs:
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
           FINAL_REASON: ${{ steps.final.outputs.reason }}
           HAS_CHANGES: ${{ steps.changes.outputs.has-changes }}
+          PR_BASE: ${{ inputs.pr-base }}
         run: |
           echo "## Weekly Update" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "$HAS_CHANGES" = "true" ]; then
-            COMMIT_COUNT=$(git rev-list --count origin/${{ inputs.pr-base }}..HEAD 2>/dev/null || echo 0)
+            COMMIT_COUNT=$(git rev-list --count "origin/${PR_BASE}..HEAD" 2>/dev/null || echo 0)
             echo "**Branch:** \`${BRANCH_NAME}\`" >> $GITHUB_STEP_SUMMARY
             echo "**Commits:** ${COMMIT_COUNT}" >> $GITHUB_STEP_SUMMARY
             echo "**Status:** ${FINAL_REASON}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -1,0 +1,454 @@
+name: 🔄 Weekly Update
+
+# Reusable weekly-update workflow for socket-* repos.
+#
+# Each consumer repo's `.github/workflows/weekly-update.yml` becomes a thin
+# delegator that invokes this workflow. The actual update logic lives in the
+# consumer repo's `/updating` skill, which this workflow calls via Claude Code.
+#
+# The `/updating` skill is the umbrella — it reads repo state (presence of
+# `xport.json`, `.gitmodules`) and delegates to `updating-xport` /
+# `updating-upstream` / `updating-workflows` as applicable.
+#
+# Dependencies:
+#   - SocketDev/socket-registry/.github/actions/setup-and-install
+#   - SocketDev/socket-registry/.github/actions/setup-git-signing
+#   - SocketDev/socket-registry/.github/actions/cleanup-git-signing
+
+on:
+  workflow_call:
+    inputs:
+      branch-prefix:
+        description: 'Branch name prefix for the PR branch (date suffix added automatically)'
+        required: false
+        type: string
+        default: 'weekly-update'
+      check-timeout-minutes:
+        description: 'Timeout for the check-updates job'
+        required: false
+        type: number
+        default: 10
+      checkout-fetch-depth:
+        description: 'Fetch depth for checkout (0 = full history; recommended for submodule drift analysis)'
+        required: false
+        type: string
+        default: '0'
+      checkout-submodules:
+        description: 'Submodule init mode: "false" (no submodules), "true" (top-level only), or "recursive"'
+        required: false
+        type: string
+        default: 'false'
+      fix-model:
+        description: 'Claude model for the fix-test-failures step (escalation after haiku update)'
+        required: false
+        type: string
+        default: 'sonnet'
+      fix-timeout-minutes:
+        description: 'Timeout for the fix-test-failures step'
+        required: false
+        type: number
+        default: 15
+      pr-base:
+        description: 'Base branch for the PR'
+        required: false
+        type: string
+        default: 'main'
+      pr-body-extra:
+        description: 'Optional markdown appended to the PR body (e.g., cross-linked PR references for cascade tracking)'
+        required: false
+        type: string
+        default: ''
+      pr-title-prefix:
+        description: 'PR title prefix (date suffix added automatically: "... (YYYY-MM-DD)")'
+        required: false
+        type: string
+        default: 'chore(deps): weekly dependency update'
+      test-setup-script:
+        description: 'Command to run before tests (e.g., "pnpm run build")'
+        required: false
+        type: string
+        default: 'pnpm run build'
+      test-script:
+        description: 'Test command'
+        required: false
+        type: string
+        default: 'pnpm test'
+      test-timeout-minutes:
+        description: 'Timeout for the test step'
+        required: false
+        type: number
+        default: 15
+      update-model:
+        description: 'Claude model for the update step'
+        required: false
+        type: string
+        default: 'haiku'
+      update-timeout-minutes:
+        description: 'Timeout for the update step'
+        required: false
+        type: number
+        default: 10
+      updating-skill:
+        description: 'Skill to invoke for the update. Defaults to the /updating umbrella.'
+        required: false
+        type: string
+        default: 'updating'
+      validate-file-patterns:
+        description: 'Shell case-glob patterns (pipe-separated) of file paths allowed to change during the update. Default covers npm + submodules + xport manifest; add source patterns for repos that auto-fix source.'
+        required: false
+        type: string
+        default: 'package.json|*/package.json|pnpm-lock.yaml|*/pnpm-lock.yaml|.npmrc|pnpm-workspace.yaml|.gitmodules|xport.json'
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key for Claude Code invocations'
+        required: true
+      BOT_GPG_PRIVATE_KEY:
+        description: 'GPG private key for signing commits'
+        required: true
+      SOCKET_API_KEY:
+        description: 'Socket API key — sfw-enterprise instead of sfw-free when provided'
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  check-updates:
+    name: Check for updates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: ${{ inputs.check-timeout-minutes }}
+    outputs:
+      has-updates: ${{ steps.check.outputs.has-updates }}
+    steps:
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f9f6e265d2fb36f7d1c6b557bde308d92151a670 # main
+        with:
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
+
+      - name: Check for actionable updates
+        id: check
+        shell: bash
+        run: |
+          HAS_UPDATES=false
+
+          # npm outdated check
+          if pnpm outdated 2>/dev/null | grep -qv "No outdated"; then
+            HAS_UPDATES=true
+          fi
+
+          # xport drift check (exit code 2 = drift; 0 = clean; 1 = schema error)
+          if [ -f xport.json ]; then
+            set +e
+            pnpm run xport --json > /tmp/xport-report.json 2>&1
+            XPORT_EXIT=$?
+            set -e
+            if [ "$XPORT_EXIT" = "2" ]; then
+              HAS_UPDATES=true
+            fi
+          fi
+
+          # Plain submodule check (for repos without xport)
+          if [ -f .gitmodules ] && [ ! -f xport.json ]; then
+            # Any submodule with upstream commits past its current pin?
+            while IFS= read -r SM; do
+              (cd "$SM" && git fetch origin --tags --quiet 2>/dev/null || true)
+              BEHIND=$(cd "$SM" && git rev-list --count HEAD..origin/HEAD 2>/dev/null || echo 0)
+              if [ "$BEHIND" -gt 0 ]; then
+                HAS_UPDATES=true
+                break
+              fi
+            done < <(git config --file .gitmodules --get-regexp path | awk '{print $2}')
+          fi
+
+          echo "has-updates=$HAS_UPDATES" >> $GITHUB_OUTPUT
+
+  apply-updates:
+    name: Apply updates via /updating skill
+    needs: check-updates
+    if: needs.check-updates.outputs.has-updates == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f9f6e265d2fb36f7d1c6b557bde308d92151a670 # main
+        with:
+          checkout-fetch-depth: ${{ inputs.checkout-fetch-depth }}
+          socket-api-key: ${{ secrets.SOCKET_API_KEY }}
+
+      - name: Initialize submodules
+        if: inputs.checkout-submodules != 'false'
+        shell: bash
+        run: |
+          if [ "${{ inputs.checkout-submodules }}" = "recursive" ]; then
+            git submodule update --init --recursive
+          else
+            git submodule update --init
+          fi
+
+      - name: Create update branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        run: |
+          BRANCH_NAME="${BRANCH_PREFIX}-$(date +%Y%m%d)"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git checkout -b "$BRANCH_NAME"
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@f9f6e265d2fb36f7d1c6b557bde308d92151a670 # main
+        with:
+          gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+
+      - name: Run /updating skill
+        id: update
+        timeout-minutes: ${{ inputs.update-timeout-minutes }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_ACTIONS: 'true'
+          UPDATE_MODEL: ${{ inputs.update-model }}
+          UPDATING_SKILL: ${{ inputs.updating-skill }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY not set — aborting"
+            echo "success=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+          set +e
+          claude --print \
+            --allowedTools "Bash(pnpm:*)" "Bash(git:*)" "Bash(jq:*)" "Read" "Write" "Edit" "Glob" "Grep" \
+            --model "$UPDATE_MODEL" \
+            --max-turns 25 \
+            "/$UPDATING_SKILL — Run the $UPDATING_SKILL skill to update everything applicable to this repo (npm, xport, submodules, workflow pins). CI mode: skip builds/tests. Create atomic commits. Do NOT push or create a PR; this workflow handles that." \
+            2>&1 | tee claude-update.log
+          CLAUDE_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$CLAUDE_EXIT" -eq 0 ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run tests
+        id: tests
+        if: steps.update.outputs.success == 'true'
+        timeout-minutes: ${{ inputs.test-timeout-minutes }}
+        env:
+          TEST_SETUP_SCRIPT: ${{ inputs.test-setup-script }}
+          TEST_SCRIPT: ${{ inputs.test-script }}
+        run: |
+          set +e
+          if [ -n "$TEST_SETUP_SCRIPT" ]; then
+            bash -c "$TEST_SETUP_SCRIPT" 2>&1 | tee build-output.log
+            BUILD_EXIT=${PIPESTATUS[0]}
+          else
+            BUILD_EXIT=0
+            : > build-output.log
+          fi
+
+          bash -c "$TEST_SCRIPT" 2>&1 | tee test-output.log
+          TEST_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$BUILD_EXIT" -eq 0 ] && [ "$TEST_EXIT" -eq 0 ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            {
+              echo "BUILD_LOG<<GHEOF"
+              tail -100 build-output.log
+              echo "GHEOF"
+              echo "TEST_LOG<<GHEOF"
+              tail -100 test-output.log
+              echo "GHEOF"
+            } >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fix test failures
+        id: fix
+        if: steps.update.outputs.success == 'true' && steps.tests.outputs.success == 'false'
+        timeout-minutes: ${{ inputs.fix-timeout-minutes }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_ACTIONS: 'true'
+          FIX_MODEL: ${{ inputs.fix-model }}
+          BUILD_LOG: ${{ steps.tests.outputs.BUILD_LOG }}
+          TEST_LOG: ${{ steps.tests.outputs.TEST_LOG }}
+        run: |
+          set +e
+          claude --print \
+            --allowedTools "Bash(pnpm:*)" "Bash(git:*)" "Read" "Write" "Edit" "Glob" "Grep" \
+            --model "$FIX_MODEL" \
+            --max-turns 25 \
+            "Dependency updates were applied but tests are failing. Fix the failures and commit fixes atomically. Do NOT push or create a PR.
+
+          Build output (last 100 lines):
+          $BUILD_LOG
+
+          Test output (last 100 lines):
+          $TEST_LOG" \
+            2>&1 | tee claude-fix.log
+          FIX_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$FIX_EXIT" -eq 0 ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set final status
+        id: final
+        if: always()
+        env:
+          UPDATE_SUCCESS: ${{ steps.update.outputs.success }}
+          TESTS_SUCCESS: ${{ steps.tests.outputs.success }}
+          FIX_SUCCESS: ${{ steps.fix.outputs.success }}
+        run: |
+          if [ "$UPDATE_SUCCESS" != "true" ]; then
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "reason=update-failed" >> $GITHUB_OUTPUT
+          elif [ "$TESTS_SUCCESS" = "true" ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+            echo "reason=tests-passed" >> $GITHUB_OUTPUT
+          elif [ "$FIX_SUCCESS" = "true" ]; then
+            echo "success=true" >> $GITHUB_OUTPUT
+            echo "reason=fixes-applied" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "reason=fixes-failed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate changes
+        id: validate
+        if: steps.final.outputs.success == 'true'
+        env:
+          VALIDATE_PATTERNS: ${{ inputs.validate-file-patterns }}
+        run: |
+          UNEXPECTED=""
+          # Build a case-glob test from pipe-separated patterns
+          PATTERNS=$(echo "$VALIDATE_PATTERNS" | tr '|' ' ')
+          for file in $(git diff --name-only origin/${{ inputs.pr-base }}..HEAD); do
+            MATCH=false
+            for pat in $PATTERNS; do
+              case "$file" in
+                $pat) MATCH=true; break ;;
+              esac
+            done
+            [ "$MATCH" = "false" ] && UNEXPECTED="$UNEXPECTED $file"
+          done
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::warning::Non-allowlisted files modified:$UNEXPECTED"
+          fi
+          echo "valid=true" >> $GITHUB_OUTPUT
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ "$(git rev-list --count HEAD ^origin/${{ inputs.pr-base }})" -gt 0 ]; then
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push branch
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
+        run: git push origin "$BRANCH_NAME"
+
+      - name: Create pull request
+        if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
+          PR_TITLE_PREFIX: ${{ inputs.pr-title-prefix }}
+          PR_BASE: ${{ inputs.pr-base }}
+          PR_BODY_EXTRA: ${{ inputs.pr-body-extra }}
+        run: |
+          COMMITS=$(git log --oneline origin/${PR_BASE}..HEAD)
+          COMMIT_COUNT=$(git rev-list --count origin/${PR_BASE}..HEAD)
+
+          PR_BODY="## Weekly Update"$'\n\n'
+          PR_BODY+="Automated weekly update — runs the \`/updating\` skill umbrella (npm + xport + submodules + workflow pins)."$'\n\n'
+          if [ -n "$PR_BODY_EXTRA" ]; then
+            PR_BODY+="$PR_BODY_EXTRA"$'\n\n'
+          fi
+          PR_BODY+="---"$'\n\n'
+          PR_BODY+="### Commits (${COMMIT_COUNT})"$'\n\n'
+          PR_BODY+="<details><summary>View commit history</summary>"$'\n\n'
+          PR_BODY+="\`\`\`"$'\n'
+          PR_BODY+="${COMMITS}"$'\n'
+          PR_BODY+="\`\`\`"$'\n\n'
+          PR_BODY+="</details>"$'\n\n'
+          PR_BODY+="---"$'\n\n'
+          PR_BODY+="<sub>Generated by SocketDev/socket-registry weekly-update.yml reusable workflow.</sub>"
+
+          gh pr create \
+            --title "${PR_TITLE_PREFIX} ($(date +%Y-%m-%d))" \
+            --body "$PR_BODY" \
+            --draft \
+            --head "$BRANCH_NAME" \
+            --base "$PR_BASE"
+
+      - name: Add job summary
+        if: always()
+        env:
+          BRANCH_NAME: ${{ steps.branch.outputs.branch }}
+          FINAL_REASON: ${{ steps.final.outputs.reason }}
+          HAS_CHANGES: ${{ steps.changes.outputs.has-changes }}
+        run: |
+          echo "## Weekly Update" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$HAS_CHANGES" = "true" ]; then
+            COMMIT_COUNT=$(git rev-list --count origin/${{ inputs.pr-base }}..HEAD 2>/dev/null || echo 0)
+            echo "**Branch:** \`${BRANCH_NAME}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Commits:** ${COMMIT_COUNT}" >> $GITHUB_STEP_SUMMARY
+            echo "**Status:** ${FINAL_REASON}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No changes to apply." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload Claude logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: claude-weekly-update-${{ github.run_id }}
+          path: |
+            claude-update.log
+            claude-fix.log
+            build-output.log
+            test-output.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@f9f6e265d2fb36f7d1c6b557bde308d92151a670 # main
+        if: always()
+
+  notify:
+    name: Notify
+    needs: [check-updates, apply-updates]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Report
+        env:
+          HAS_UPDATES: ${{ needs.check-updates.outputs.has-updates }}
+          APPLY_RESULT: ${{ needs.apply-updates.result }}
+        run: |
+          if [ "$HAS_UPDATES" = "true" ]; then
+            echo "Weekly update workflow completed (apply-updates: $APPLY_RESULT)"
+          else
+            echo "No updates available — all dependencies up to date."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,11 @@ Color the icon only, using `yoctocolors-cjs` (NOT ESM `yoctocolors`):
 
 ```javascript
 import colors from 'yoctocolors-cjs'
-`${colors.green('✓')} ${msg}`
-`${colors.red('✗')} ${msg}`
-`${colors.yellow('⚠')} ${msg}`
-`${colors.blue('ℹ')} ${msg}`
-`${colors.cyan('→')} ${msg}`
+const success = `${colors.green('✓')} ${msg}`
+const error = `${colors.red('✗')} ${msg}`
+const warning = `${colors.yellow('⚠')} ${msg}`
+const info = `${colors.blue('ℹ')} ${msg}`
+const step = `${colors.cyan('→')} ${msg}`
 ```
 
 Use emojis sparingly. Prefer text symbols for terminal compatibility.
@@ -300,7 +300,7 @@ Actions and workflows reference each other by full 40-char SHA pinned to main. W
 ### Dependency Alignment
 
 - Core: @typescript/native-preview (tsgo), @types/node, typescript-eslint (unified only)
-- DevDeps: @dotenvx/dotenvx, @vitest/coverage-v8, del-cli, eslint, eslint-plugin-*, globals, husky, knip, lint-staged, npm-run-all2, oxfmt, taze, type-coverage, vitest, yargs-parser, yoctocolors-cjs
+- DevDeps: @dotenvx/dotenvx, @vitest/coverage-v8, del-cli, eslint, eslint-plugin-\*, globals, husky, knip, lint-staged, npm-run-all2, oxfmt, taze, type-coverage, vitest, yargs-parser, yoctocolors-cjs
 - **FORBIDDEN**: separate `@typescript-eslint/*` packages; use unified `typescript-eslint`
 - **TSGO PRESERVATION**: never replace tsgo with tsc
 - Update: `pnpm run taze`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Actions and workflows reference each other by full 40-char SHA pinned to main. W
 
 - L3/L4-only changes (reusable workflow edits, no L1/L2 action changes): skip to Layer 4 bump
 - Don't clobber third-party SHAs during blanket replacements
-- Consumer repos: **direct push** — socket-btm, sdxgen, ultrathink; **PR** — socket-cli, socket-lib, socket-sdk-js, socket-packageurl-js. Note: `sdxgen` local checkout is `socket-sdxgen/` but GitHub repo is `SocketDev/sdxgen` — use bare name for `gh` commands.
+- Consumer repos: **direct push** — socket-btm, sdxgen, stuie, ultrathink; **PR** — socket-cli, socket-lib, socket-sdk-js, socket-packageurl-js. Note: `sdxgen` local checkout is `socket-sdxgen/` but GitHub repo is `SocketDev/sdxgen` — use bare name for `gh` commands. `stuie` local checkout is `socket-tui/` but GitHub repo is `SocketDev/stuie`.
 
 ### CI Testing Infrastructure
 


### PR DESCRIPTION
## Summary

Adds the **xport lock-step manifest family** to socket-registry: 2 new skills, 1 enriched skill, 1 new Layer 3 reusable workflow, and supporting docs. Consumer repos (socket-tui, socket-btm, socket-sdxgen, ultrathink) already carry the xport canonical files (schema + harness + per-repo manifest) and the \`pnpm run xport\` drift detector — this PR lands the skill canonicals + shared weekly-update infrastructure that those repos hook into.

## What's added

**Skills** (in \`.claude/skills/\`):
- \`updating-xport/SKILL.md\` — act on \`xport.json\` drift per row kind. Auto-bumps \`version-pin\` rows under their \`upgrade_policy\`; emits advisory notes for \`file-fork\` / \`feature-parity\` / \`spec-conformance\` / \`lang-parity\`.
- \`updating-upstream/SKILL.md\` — bump git submodules in \`.gitmodules\` to latest stable tag; skips submodules owned by xport \`version-pin\` rows.
- \`updating/SKILL.md\` enriched to delegate to \`updating-xport\` (if \`xport.json\` exists) and \`updating-upstream\` (if \`.gitmodules\` exists).

**Reusable workflow** (\`.github/workflows/weekly-update.yml\`):
- New Layer 3 reusable. Invokes the \`/updating\` skill umbrella via Claude Code (haiku for update; sonnet escalation for test fixes).
- Configurable: \`branch-prefix\`, \`checkout-submodules\`, \`validate-file-patterns\`, \`update-model\`, \`fix-model\`, \`test-setup-script\`, \`test-script\`, etc.
- Replaces per-repo 300-470 line weekly-update workflows with thin delegators.

**Docs**:
- \`CLAUDE.md\` — stuie added to direct-push list.
- \`updating-workflows/reference.md\` — \`weekly-update.yml\` registered as Layer 3; stuie added to the propagation list.

## Cascade context

Layer 3 change. Per \`updating-workflows/reference.md\`:
1. Merge this PR → merge SHA on main = **propagation SHA**.
2. Layer 4 PR updates \`_local-not-for-reuse-weekly-update.yml\` (optional).
3. Consumer repos update their per-repo \`.github/workflows/weekly-update.yml\` to delegate here.

## Test plan

- [ ] CI green on this branch
- [ ] SKILL.md frontmatter passes
- [ ] Dry-run the new reusable via \`workflow_dispatch\` once a consumer delegates