### PR TITLE
chore(ci): bump socket-registry action refs to main (d54c36d0)

### DIFF
--- a/.github/workflows/_local-not-for-reuse-ci.yml
+++ b/.github/workflows/_local-not-for-reuse-ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
     with:
       test-script: 'pnpm run test --all --fast'
       node-versions: '["22", "24"]'
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
         with:
           node-version: 22
 

--- a/.github/workflows/_local-not-for-reuse-provenance.yml
+++ b/.github/workflows/_local-not-for-reuse-provenance.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   publish:
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
     with:
       debug: ${{ inputs.debug }}
       force-registry: ${{ inputs.force-registry }}

--- a/.github/workflows/_local-not-for-reuse-weekly-update.yml
+++ b/.github/workflows/_local-not-for-reuse-weekly-update.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
         with:
           socket-api-key: ${{ secrets.SOCKET_API_KEY }}
 
@@ -62,7 +62,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
         with:
           checkout-fetch-depth: '0'
           socket-api-key: ${{ secrets.SOCKET_API_KEY }}
@@ -86,7 +86,7 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -292,7 +292,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@34fef52be917f89dbbeb464860f2aaf0f3812c40 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@d54c36d0bed05ffffbe8b14e7663927eaa19d5df # main
         if: always()
 
   notify:


### PR DESCRIPTION
## Summary

Layer 4 SHA cascade following the merge of #269 (feat(skills): xport + weekly-update reusable).

Updates all \`_local-not-for-reuse-*.yml\` workflows from \`@34fef52b\` → \`@d54c36d0\`.

## Why

d54c36d0 is the post-merge SHA of #269, where the new Layer 3 \`weekly-update.yml\` reusable workflow + \`updating-xport\` / \`updating-upstream\` skills landed. External consumer repos will pin this same SHA to reference the new infrastructure.

Per the cascade convention in \`.claude/skills/updating-workflows/reference.md\`, this is a Layer 4 pin bump — no behavior change, just SHA pin updates.

## Test plan

- [ ] CI passes
- [ ] No stale refs: \`grep -rn "SocketDev/socket-registry" .github/ | grep "@" | grep -v d54c36d0\` returns only third-party refs