### PR TITLE
chore(claude): fleet-gold CLAUDE.md + check-new-deps hook improvements

### DIFF
--- a/.claude/hooks/check-new-deps/index.mts
+++ b/.claude/hooks/check-new-deps/index.mts
@@ -17,7 +17,9 @@
 //   0 = allow (no new deps, all clean, or non-dep file)
 //   2 = block (malware detected by Socket.dev)
 
+import path from 'node:path'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 
 import {
   parseNpmSpecifier,
@@ -33,6 +35,13 @@ import {
 } from '@socketsecurity/lib/paths/normalize'
 import { SocketSdk } from '@socketsecurity/sdk'
 import type { MalwareCheckPackage } from '@socketsecurity/sdk'
+
+// Local mirror of build-infra/lib/error-utils#errorMessage. Hook runs
+// standalone (no workspace deps beyond @socketsecurity/*) so we can't import
+// the shared helper, but the contract is identical.
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
 
 const logger = getDefaultLogger()
 
@@ -275,7 +284,7 @@ const extractors: Record<string, Extractor> = {
 
 // --- main (only when executed directly, not imported) ---
 
-if (import.meta.filename === process.argv[1]) {
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
   // Read the full JSON blob from stdin (piped by Claude Code).
   let input = ''
   for await (const chunk of process.stdin) input += chunk
@@ -286,9 +295,7 @@ if (import.meta.filename === process.argv[1]) {
   } catch (e) {
     // Fail-block (exit 2) on malformed input — a security hook should never
     // silently pass through when it can't parse its own contract.
-    logger.error(
-      `Socket: malformed hook input: ${e instanceof Error ? e.message : String(e)}`,
-    )
+    logger.error(`Socket: malformed hook input: ${errorMessage(e)}`)
     process.exitCode = 2
     throw e
   }
@@ -416,10 +423,7 @@ async function checkDepsBatch(
     }
   } catch (e) {
     // Network failure — log and allow all deps through.
-    logger.warn(
-      `Socket: network error`
-      + ` (${e instanceof Error ? e.message : String(e)}), allowing all`
-    )
+    logger.warn(`Socket: network error (${errorMessage(e)}), allowing all`)
   }
 
   return blocked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,31 @@
 - Use "you/your" when speaking directly; use names when referencing their commits/contributions
 - Example: git shows "John-David Dalton <jdalton@example.com>" → "John-David"
 
+## PARALLEL CLAUDE SESSIONS - WORKTREE REQUIRED
+
+**This repo may have multiple Claude sessions running concurrently against the same checkout, against parallel git worktrees, or against sibling clones.** Several common git operations are hostile to that and silently destroy or hijack the other session's work.
+
+- **FORBIDDEN in the primary checkout** (the one another Claude may be editing):
+  - `git stash` — shared stash store; another session can `pop` yours.
+  - `git add -A` / `git add .` — sweeps files belonging to other sessions.
+  - `git checkout <branch>` / `git switch <branch>` — yanks the working tree out from under another session.
+  - `git reset --hard` against a non-HEAD ref — discards another session's commits.
+- **REQUIRED for branch work**: spawn a worktree instead of switching branches in place. Each worktree has its own HEAD, so branch operations inside it are safe.
+
+  ```bash
+  # From the primary checkout — does NOT touch the working tree here.
+  git worktree add -b <task-branch> ../<repo>-<task> main
+  cd ../<repo>-<task>
+  # edit, commit, push from here; the primary checkout is untouched.
+  cd -
+  git worktree remove ../<repo>-<task>
+  ```
+
+- **REQUIRED for staging**: surgical `git add <specific-file> [<file>…]` with explicit paths. Never `-A` / `.`.
+- **If you need a quick WIP save**: commit on a new branch from inside a worktree, not a stash.
+
+The umbrella rule: never run a git command that mutates state belonging to a path other than the file you just edited.
+
 ## PRE-ACTION PROTOCOL
 
 **MANDATORY**: Review CLAUDE.md before any action. No exceptions.


### PR DESCRIPTION
Two fleet-standard updates:

## 1. CLAUDE.md — parallel-Claude-hostile git operations (original PR scope)

Multiple Claude sessions can run concurrently against the same checkout, parallel worktrees, or sibling clones. Document which git ops break that contract (\`stash\`, \`add -A\`, branch switching, \`reset --hard\` non-HEAD) and the safe alternatives (worktrees, surgical add).

## 2. check-new-deps hook — fleet-gold improvements

Three improvements from the socket-repo-template gold standard:

- **Canonical isMainModule**: \`fileURLToPath(import.meta.url) === path.resolve(process.argv[1])\` — widest cross-platform support. \`import.meta.filename\` is undefined under Node <20.11 ESM loaders and has edge cases with symlinks.
- **Local errorMessage() helper**: replaces inline \`e instanceof Error ? e.message : String(e)\` ternaries at both sites (malformed-input error + network-error warn). Mirrors \`build-infra/lib/error-utils\` — inlined so the hook stays workspace-dep-free.
- **Inline ternary → helper**: both call sites collapsed to single concise lines.

Same change applied across the fleet to ensure consistent behavior.