### PR TITLE
chore(test): pin vitest cache to node_modules/.cache

### DIFF
--- a/.config/vitest.config.mts
+++ b/.config/vitest.config.mts
@@ -22,6 +22,9 @@ function toPosixPath(filepath) {
 }
 
 export default defineConfig({
+  // Keep vitest's cache under node_modules so `pnpm install`
+  // clears it automatically — no dedicated clean step.
+  cacheDir: './node_modules/.cache/vitest',
   // Disabled complex transform plugins - we now test src/ directly
   // plugins: [
   //   createImportTransformPlugin(isCoverageEnabled, __dirname),

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ package-lock.json
 .eslintcache
 
 # Build artifacts
-**/.cache
 **/coverage
 **/dist
 **/html


### PR DESCRIPTION
## Summary

- Adds `cacheDir: './node_modules/.cache/vitest'` to `.config/vitest.config.mts`. `pnpm install` already wipes `node_modules/`, giving free cache invalidation without a dedicated clean step.
- Drops `**/.cache` from `.gitignore` — nothing writes to a top-level `.cache/` anymore.

## Fleet context

Pattern already landed or queued in: `../socket-packageurl-js`, `../socket-sdk-js` (#616), `../socket-cli` (#1274), `../socket-lib` (#189), `../socket-btm` (#118), `../meander`.

## Test plan

Config-only; CI will verify.