### PR TITLE
chore(scaffolding): adopt token-guard + path-guard from socket-repo-template

### DIFF
--- a/.claude/hooks/path-guard/README.md
+++ b/.claude/hooks/path-guard/README.md
@@ -1,0 +1,66 @@
+# path-guard
+
+Claude Code `PreToolUse` hook that refuses `Edit`/`Write` tool calls that would *construct* a multi-segment build/output path inline in a `.mts` or `.cts` file. Mandatory across the Socket fleet — every repo ships this file byte-for-byte via `scripts/sync-scaffolding.mjs`.
+
+**Mantra: 1 path, 1 reference.**
+
+Construct a path *once* in the canonical `paths.mts` (or a build-infra helper); reference the computed value everywhere else.
+
+## What it blocks
+
+| Rule | Example | Fix |
+|------|---------|-----|
+| **A** — Multi-stage path constructed inline | `path.join(PKG, 'build', mode, 'out', 'Final', name)` | Construct in the package's `scripts/paths.mts` (or use `getFinalBinaryPath` from `build-infra/lib/paths`); import the computed value here |
+| **B** — Cross-package path traversal | `path.join(PKG, '..', 'lief-builder', 'build', ...)` | Add `lief-builder: workspace:*` as a dep; import its `paths.mts` via the workspace `exports` field |
+
+The hook fires on `Edit` and `Write` tool calls when the target path ends in `.mts` or `.cts`. Other extensions (`.ts`, `.mjs`, `.js`, `.yml`, `.json`, `.md`) pass through — TS path code lives in `.mts` per CLAUDE.md, and other file types are covered by the `scripts/check-paths.mts` gate at commit time.
+
+## What it allows
+
+- Edits to a `paths.mts` (canonical constructor — every package's source of truth).
+- Edits to `scripts/check-paths.mts` (the gate, which legitimately enumerates patterns).
+- Edits to this hook's own files (the test suite has to enumerate the same patterns).
+- Edits to `scripts/check-consistency.mts` (existing path-scanning gate).
+- `path.join` calls with a single stage segment (e.g. `path.join(packageRoot, 'build', 'temp')`) — that's a one-off helper path, not a multi-stage build output.
+- `path.join` calls with no stage segments at all (most general-purpose joins).
+- Any string concatenation that doesn't go through `path.join` — the hook is regex-based and intentionally narrow; the gate runs a deeper scan at commit time.
+
+## Stage segments the hook recognizes
+
+These come from `build-infra/lib/constants.mts` `BUILD_STAGES` plus the lowercase directory-name siblings used by some builders:
+
+`Final`, `Release`, `Stripped`, `Compressed`, `Optimized`, `Synced`, `wasm`, `downloaded`
+
+Two or more in the same `path.join` call (or one stage + one of `'build'`/`'out'` + one mode `'dev'`/`'prod'`) triggers Rule A.
+
+## Known sibling packages (for Rule B)
+
+The hook recognizes Rule B traversals only when the next segment after `..` is a known fleet package name:
+
+`binflate`, `binject`, `binpress`, `bin-infra`, `build-infra`, `codet5-models-builder`, `curl-builder`, `iocraft-builder`, `ink-builder`, `libpq-builder`, `lief-builder`, `minilm-builder`, `models`, `napi-go`, `node-smol-builder`, `onnxruntime-builder`, `opentui-builder`, `stubs-builder`, `ultraviolet-builder`, `yoga-layout-builder`
+
+When a new package joins the workspace, add it here.
+
+## Control flow
+
+The hook reads the tool-use payload from stdin, type-checks `tool_name === 'Edit'` or `'Write'`, filters to `.mts`/`.cts` files, and runs `check(source)`. Any rule violation `throw`s a typed `BlockError`; a single top-level `try/catch` in `main()` writes the block message to stderr and sets `process.exitCode = 2`.
+
+Hook bugs fail **open** — a crash in the hook writes a log line and returns exit 0 so legitimate work isn't blocked on a bad deploy. The companion `scripts/check-paths.mts` gate runs a thorough whole-repo scan at `pnpm check` time, catching anything the hook misses.
+
+## Testing
+
+```bash
+pnpm --filter @socketsecurity/hook-path-guard test
+```
+
+Adding a new detection pattern: update `STAGE_SEGMENTS` (or `KNOWN_SIBLING_PACKAGES`) in `index.mts`, add a positive and negative test in `test/path-guard.test.mts`.
+
+## Updating across the fleet
+
+This file is in `IDENTICAL_FILES` in `scripts/sync-scaffolding.mjs` (in `socket-repo-template`). After editing, run from `socket-repo-template`:
+
+```bash
+node scripts/sync-scaffolding.mjs --all --fix
+```
+
+to propagate the change to every fleet repo.

--- a/.claude/hooks/path-guard/index.mts
+++ b/.claude/hooks/path-guard/index.mts
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+// Claude Code PreToolUse hook — path-guard firewall.
+//
+// Mantra: 1 path, 1 reference.
+//
+// Blocks Edit/Write tool calls that would *construct* a multi-segment
+// build/output path inline in a `.mts` or `.cts` file, instead of
+// importing the constructed value from the canonical `paths.mts` (or a
+// build-infra helper). This fires BEFORE the write lands; exit code 2
+// makes Claude Code refuse the tool call so the diff never touches the
+// repo. The model sees the rejection reason on stderr and retries with
+// an import-based approach.
+//
+// What the hook checks (subset of the gate's rules — diff-local only):
+//
+//   Rule A — Multi-stage path construction: a `path.join(...)` call or
+//   string-template that stitches together two or more "stage" segments
+//   like `'Final'`, `'Release'`, `'Stripped'`, `'Compressed'`,
+//   `'Optimized'`, `'Synced'`, `'wasm'`, `'downloaded'` together with
+//   `'build'` / `'out'` / a mode (`'dev'`/`'prod'`) or platform-arch.
+//   Outside a `paths.mts` file, this is always a violation: the
+//   construction belongs in a helper, every consumer imports the
+//   computed value.
+//
+//   Rule B — Cross-package traversal: `path.join(*, '..', '<sibling
+//   package>', 'build', ...)` reaches into a sibling's build output
+//   without going through its `exports`. Forces consumers to declare a
+//   workspace dep and import the sibling's `paths.mts`. The R28 yoga/
+//   ink bug — ink hand-building yoga's wasm path and missing the
+//   `wasm/` segment — is exactly the failure mode this prevents.
+//
+// What the hook does NOT check (the gate handles repo-wide concerns):
+//
+//   Rule C — workflow YAML repetition (gate scans .yml files).
+//   Rule D — comment-encoded paths (gate scans comments + JSDoc).
+//   Rule F — same path reconstructed in multiple files (needs whole-
+//   repo state).
+//   Rule G — Makefile / Dockerfile / shell-script paths (different
+//   tool, gate covers).
+//
+// Scope:
+//
+//   - Fires only on `Edit` and `Write` tool calls.
+//   - Skips files NOT ending in `.mts` or `.cts`. TS path code lives
+//     there; .ts/.mjs/.js sources in `additions/` have different
+//     constraints per CLAUDE.md.
+//   - Skips when the target itself is a `paths.mts` (canonical
+//     constructor), the gate (`scripts/check-paths.mts`), or this hook
+//     — those files legitimately enumerate stage segments.
+//
+// Control flow uses a `BlockError` thrown from check helpers so every
+// short-circuit path goes through a single `process.exitCode = 2` drop
+// at the top-level catch — no scattered `process.exit(2)` that can race
+// with buffered stderr. The hook fails OPEN on its own bugs (exit 0 +
+// log) so a bad deploy of the hook can't brick the session.
+
+import process from 'node:process'
+
+// "Stage" segments — appearing two or more in the same path.join /
+// template literal is a Rule A violation. These come from
+// build-infra/lib/constants.mts BUILD_STAGES plus their lowercase
+// directory-name siblings used by some builders (yoga's `wasm/`,
+// build-infra's `downloaded/`).
+const STAGE_SEGMENTS = new Set([
+  'Final',
+  'Release',
+  'Stripped',
+  'Compressed',
+  'Optimized',
+  'Synced',
+  'wasm',
+  'downloaded',
+])
+
+// "Build-root" segments — at least one must be present together with a
+// stage segment to confirm we're constructing a build output path
+// rather than something coincidental. Example: `path.join(SRC,
+// 'wasm', 'lib')` shouldn't fire (no build root); `path.join(PKG,
+// 'build', 'wasm', 'out', 'Final')` should (build root + wasm + out +
+// Final).
+const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
+
+// Mode segments — appearing alongside stage + build-root tightens the
+// match further. `'dev'` and `'prod'` alone are too generic; we count
+// them as a confirming signal, not a trigger.
+const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
+
+// Sibling Socket-fleet packages whose build output is reached via
+// `path.join(*, '..', '<name>', 'build', ...)`. Union of all packages
+// across the Socket fleet — the hook is byte-identical via
+// sync-scaffolding, so listing every fleet package keeps Rule B firing
+// in any repo. When a new package joins the workspace, add it here
+// and propagate via `node scripts/sync-scaffolding.mjs --all --fix`
+// from socket-repo-template.
+const KNOWN_SIBLING_PACKAGES = new Set([
+  // socket-btm
+  'binflate',
+  'binject',
+  'binpress',
+  'bin-infra',
+  'build-infra',
+  'codet5-models-builder',
+  'curl-builder',
+  'iocraft-builder',
+  'ink-builder',
+  'libpq-builder',
+  'lief-builder',
+  'minilm-builder',
+  'models',
+  'napi-go',
+  'node-smol-builder',
+  'onnxruntime-builder',
+  'opentui-builder',
+  'stubs-builder',
+  'ultraviolet-builder',
+  'yoga-layout-builder',
+  // socket-cli
+  'cli',
+  'package-builder',
+  // socket-tui
+  'core',
+  'react',
+  'renderer',
+  'ultraviolet',
+  'yoga',
+  // socket-registry / ultrathink
+  'acorn',
+  'npm',
+])
+
+// File-path patterns that are exempt from the hook entirely. Edits to
+// these files legitimately need to enumerate path segments.
+const EXEMPT_FILE_PATTERNS: RegExp[] = [
+  // Any paths.mts is the canonical constructor.
+  /(^|\/)paths\.(mts|cts)$/,
+  // The gate itself and this hook — both enumerate the patterns to
+  // detect them.
+  /scripts\/check-paths\.mts$/,
+  /\.claude\/hooks\/path-guard\/index\.(mts|cts)$/,
+  /\.claude\/hooks\/path-guard\/test\//,
+  // Existing path-scanning gates that intentionally enumerate.
+  /scripts\/check-consistency\.mts$/,
+]
+
+class BlockError extends Error {
+  public readonly rule: string
+  public readonly suggestion: string
+  public readonly snippet: string
+  constructor(rule: string, suggestion: string, snippet: string) {
+    super(rule)
+    this.name = 'BlockError'
+    this.rule = rule
+    this.suggestion = suggestion
+    this.snippet = snippet.slice(0, 240) + (snippet.length > 240 ? '…' : '')
+  }
+}
+
+const stdin = (): Promise<string> =>
+  new Promise(resolve => {
+    let buf = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', chunk => (buf += chunk))
+    process.stdin.on('end', () => resolve(buf))
+  })
+
+type ToolInput = {
+  tool_name?: string
+  tool_input?: {
+    file_path?: string
+    new_string?: string
+    content?: string
+  }
+}
+
+const isInScope = (filePath: string): boolean => {
+  if (!filePath) {
+    return false
+  }
+  // Only inspect TypeScript-Module / CommonJS-Module sources. Per
+  // the user's directive, allowlist by extension.
+  if (!filePath.endsWith('.mts') && !filePath.endsWith('.cts')) {
+    return false
+  }
+  return !EXEMPT_FILE_PATTERNS.some(re => re.test(filePath))
+}
+
+const extractPathJoinArgs = (
+  source: string,
+): Array<{ snippet: string; literals: string[] }> => {
+  // Match `path.join(...)` calls and capture the comma-separated
+  // argument list. We're not parsing JS — a regex is brittle, but the
+  // hook is a fast advisory line of defense and the gate runs a more
+  // thorough whole-repo check at commit time.
+  const calls: Array<{ snippet: string; literals: string[] }> = []
+  const callRe = /\bpath\.join\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/g
+  let match: RegExpExecArray | null
+  while ((match = callRe.exec(source)) !== null) {
+    const args = match[1]
+    if (args === undefined) {
+      continue
+    }
+    // Pull out string literals from the arg list. Both single and
+    // double quotes; ignore template-literal interpolations.
+    const litRe = /(['"])((?:\\.|(?!\1)[^\\])*)\1/g
+    const literals: string[] = []
+    let lit: RegExpExecArray | null
+    while ((lit = litRe.exec(args)) !== null) {
+      const value = lit[2]
+      if (value !== undefined) {
+        literals.push(value)
+      }
+    }
+    calls.push({ snippet: match[0], literals })
+  }
+  return calls
+}
+
+const checkRuleA = (calls: ReturnType<typeof extractPathJoinArgs>): void => {
+  for (const call of calls) {
+    const stages = call.literals.filter(l => STAGE_SEGMENTS.has(l))
+    const buildRoots = call.literals.filter(l => BUILD_ROOT_SEGMENTS.has(l))
+    const modes = call.literals.filter(l => MODE_SEGMENTS.has(l))
+    // Trigger if: 2+ stage segments OR (1 stage + 1 build-root + 1 mode).
+    // Both shapes indicate a hand-built build-output path.
+    const twoStages = stages.length >= 2
+    const stagePlusContext =
+      stages.length >= 1 && buildRoots.length >= 1 && modes.length >= 1
+    if (twoStages || stagePlusContext) {
+      throw new BlockError(
+        'A — multi-stage path constructed inline',
+        'Construct this path in the owning `paths.mts` (or a build-infra helper like `getFinalBinaryPath`) and import the computed value here. 1 path, 1 reference.',
+        call.snippet,
+      )
+    }
+  }
+}
+
+const checkRuleB = (calls: ReturnType<typeof extractPathJoinArgs>): void => {
+  for (const call of calls) {
+    // Look for the sequence: `..` then a known sibling package name
+    // somewhere in the literal list. The literals come in order from
+    // the regex, so a sibling appearing AFTER a `..` segment indicates
+    // cross-package traversal.
+    let sawDotDot = false
+    for (const lit of call.literals) {
+      if (lit === '..') {
+        sawDotDot = true
+        continue
+      }
+      if (sawDotDot && KNOWN_SIBLING_PACKAGES.has(lit)) {
+        // Only fire when build-output context appears (otherwise this
+        // could be a legitimate test fixture path or shared resource).
+        const hasBuildContext = call.literals.some(
+          l => BUILD_ROOT_SEGMENTS.has(l) || STAGE_SEGMENTS.has(l),
+        )
+        if (hasBuildContext) {
+          throw new BlockError(
+            'B — cross-package path traversal',
+            `Don't reach into '${lit}'s build output via \`..\`. Add \`${lit}: workspace:*\` as a dep and import its \`paths.mts\` via the \`exports\` field. 1 path, 1 reference.`,
+            call.snippet,
+          )
+        }
+      }
+    }
+  }
+}
+
+const check = (source: string): void => {
+  const calls = extractPathJoinArgs(source)
+  if (calls.length === 0) {
+    return
+  }
+  checkRuleA(calls)
+  checkRuleB(calls)
+}
+
+const emitBlock = (filePath: string, err: BlockError): void => {
+  process.stderr.write(
+    `\n[path-guard] Blocked: ${err.rule}\n` +
+      `  Mantra: 1 path, 1 reference\n` +
+      `  File:    ${filePath}\n` +
+      `  Snippet: ${err.snippet}\n` +
+      `  Fix:     ${err.suggestion}\n\n`,
+  )
+}
+
+const main = async (): Promise<void> => {
+  const raw = await stdin()
+  if (!raw) {
+    return
+  }
+  let payload: ToolInput
+  try {
+    payload = JSON.parse(raw) as ToolInput
+  } catch {
+    return
+  }
+  if (payload.tool_name !== 'Edit' && payload.tool_name !== 'Write') {
+    return
+  }
+  const filePath = payload.tool_input?.file_path ?? ''
+  if (!isInScope(filePath)) {
+    return
+  }
+  // Edit tool sends `new_string` (the replacement); Write sends
+  // `content` (the full file). Either is the text we'd be putting on
+  // disk.
+  const source =
+    payload.tool_input?.new_string ?? payload.tool_input?.content ?? ''
+  if (!source) {
+    return
+  }
+
+  try {
+    check(source)
+  } catch (e) {
+    if (e instanceof BlockError) {
+      emitBlock(filePath, e)
+      process.exitCode = 2
+      return
+    }
+    throw e
+  }
+}
+
+main().catch(e => {
+  // Never block a tool call due to a bug in the hook itself. Log it
+  // so we notice, but fail open.
+  process.stderr.write(`[path-guard] hook error (allowing): ${e}\n`)
+  process.exitCode = 0
+})

--- a/.claude/hooks/path-guard/package.json
+++ b/.claude/hooks/path-guard/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@socketsecurity/hook-path-guard",
+  "private": true,
+  "type": "module",
+  "main": "./index.mts",
+  "exports": {
+    ".": "./index.mts"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mts"
+  }
+}

--- a/.claude/hooks/path-guard/test/path-guard.test.mts
+++ b/.claude/hooks/path-guard/test/path-guard.test.mts
@@ -1,0 +1,280 @@
+// Tests for the path-guard hook. Each `node:test` block writes a
+// mock PreToolUse payload to the hook's stdin and asserts on its exit
+// code + stderr. Exit 2 = blocked; exit 0 = allowed.
+//
+// Run: pnpm --filter @socketsecurity/hook-path-guard test
+//      (or directly: node --test test/*.test.mts)
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const HOOK = path.resolve(__dirname, '..', 'index.mts')
+
+const runHook = (
+  toolName: string,
+  filePath: string,
+  source: string,
+): { code: number; stderr: string } => {
+  const payload = JSON.stringify({
+    tool_name: toolName,
+    tool_input:
+      toolName === 'Edit'
+        ? { file_path: filePath, new_string: source }
+        : { file_path: filePath, content: source },
+  })
+  const result = spawnSync(process.execPath, [HOOK], {
+    encoding: 'utf8',
+    input: payload,
+  })
+  return {
+    code: result.status ?? -1,
+    stderr: result.stderr,
+  }
+}
+
+describe('path-guard — Rule A (multi-stage construction)', () => {
+  it('blocks two stage segments in path.join', () => {
+    const source = `
+      const p = path.join(PACKAGE_ROOT, 'wasm', 'out', 'Final', 'bin')
+    `
+    const { code, stderr } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 2)
+    assert.match(stderr, /Blocked: A/)
+    assert.match(stderr, /1 path, 1 reference/)
+  })
+
+  it('blocks build + mode + stage', () => {
+    const source = `
+      const p = path.join(PKG, 'build', 'dev', 'out', 'Final', 'binary')
+    `
+    const { code } = runHook(
+      'Edit',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 2)
+  })
+
+  it('blocks Release + Stripped together', () => {
+    const source = `
+      const p = path.join(buildDir, 'Release', 'Stripped')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/release.mts',
+      source,
+    )
+    assert.equal(code, 2)
+  })
+
+  it('allows single stage segment with one build root', () => {
+    // 'build' + 'temp' → no stage segment at all → pass
+    const source = `
+      const tmp = path.join(packageRoot, 'build', 'temp')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('allows path.join with no stage segments', () => {
+    const source = `
+      const cfg = path.join(packageRoot, 'config', 'settings.json')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+})
+
+describe('path-guard — Rule B (cross-package traversal)', () => {
+  it('blocks .. + sibling package + build context', () => {
+    const source = `
+      const lief = path.join(PKG, '..', 'lief-builder', 'build', 'Final')
+    `
+    const { code, stderr } = runHook(
+      'Write',
+      'packages/binject/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 2)
+    assert.match(stderr, /Blocked: B/)
+    assert.match(stderr, /lief-builder/)
+  })
+
+  it('allows .. + sibling without build context', () => {
+    // Reaching into a sibling for a non-build asset is allowed; the
+    // gate may still flag it but the hook is scoped to build paths.
+    const source = `
+      const cfg = path.join(PKG, '..', 'lief-builder', 'config.json')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/binject/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('does not fire on traversal to unknown directory', () => {
+    const source = `
+      const x = path.join(PKG, '..', 'fixtures', 'build', 'Final')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/test/test.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+})
+
+describe('path-guard — file-type filter', () => {
+  it('skips .ts files', () => {
+    const source = `
+      const p = path.join(PKG, 'build', 'dev', 'out', 'Final', 'bin')
+    `
+    const { code } = runHook('Write', 'packages/foo/src/index.ts', source)
+    assert.equal(code, 0)
+  })
+
+  it('skips .mjs files', () => {
+    const source = `
+      const p = path.join(PKG, 'build', 'dev', 'out', 'Final', 'bin')
+    `
+    const { code } = runHook('Write', 'additions/foo.mjs', source)
+    assert.equal(code, 0)
+  })
+
+  it('skips .yml files', () => {
+    const source = `
+      run: |
+        FINAL="build/\${MODE}/\${ARCH}/out/Final"
+    `
+    const { code } = runHook(
+      'Write',
+      '.github/workflows/foo.yml',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('inspects .mts files', () => {
+    const source = `
+      const p = path.join(PKG, 'build', 'dev', 'out', 'Final', 'bin')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 2)
+  })
+
+  it('inspects .cts files', () => {
+    const source = `
+      const p = path.join(PKG, 'build', 'dev', 'out', 'Final', 'bin')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.cts',
+      source,
+    )
+    assert.equal(code, 2)
+  })
+})
+
+describe('path-guard — exempt files', () => {
+  it('allows edits to paths.mts', () => {
+    const source = `
+      export const FINAL_DIR = path.join(PKG, 'build', 'dev', 'out', 'Final')
+    `
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/paths.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('allows edits to check-paths.mts (the gate)', () => {
+    const source = `
+      const PATTERNS = [path.join('build', 'Final', 'wasm')]
+    `
+    const { code } = runHook('Write', 'scripts/check-paths.mts', source)
+    assert.equal(code, 0)
+  })
+
+  it('allows edits to the path-guard hook itself', () => {
+    const source = `
+      const STAGES = ['Final', 'Release', 'Stripped']
+    `
+    const { code } = runHook(
+      'Write',
+      '.claude/hooks/path-guard/index.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('allows edits to path-guard tests', () => {
+    const source = `
+      const fixture = path.join('build', 'dev', 'out', 'Final')
+    `
+    const { code } = runHook(
+      'Write',
+      '.claude/hooks/path-guard/test/path-guard.test.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+})
+
+describe('path-guard — tool-name filter', () => {
+  it('skips Bash', () => {
+    const source = `path.join(PKG, 'build', 'dev', 'out', 'Final', 'bin')`
+    const { code } = runHook('Bash', '', source)
+    assert.equal(code, 0)
+  })
+
+  it('skips Read', () => {
+    const source = ''
+    const { code } = runHook('Read', 'packages/foo/scripts/build.mts', source)
+    assert.equal(code, 0)
+  })
+})
+
+describe('path-guard — bug-tolerance (fails open)', () => {
+  it('passes through invalid JSON payload', () => {
+    const result = spawnSync(process.execPath, [HOOK], {
+      encoding: 'utf8',
+      input: 'not json at all',
+    })
+    assert.equal(result.status, 0)
+  })
+
+  it('passes through empty stdin', () => {
+    const result = spawnSync(process.execPath, [HOOK], {
+      encoding: 'utf8',
+      input: '',
+    })
+    assert.equal(result.status, 0)
+  })
+})

--- a/.claude/hooks/path-guard/tsconfig.json
+++ b/.claude/hooks/path-guard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declarationMap": false,
+    "erasableSyntaxOnly": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "strict": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true
+  }
+}

--- a/.claude/hooks/token-guard/README.md
+++ b/.claude/hooks/token-guard/README.md
@@ -1,0 +1,57 @@
+# token-guard
+
+Claude Code `PreToolUse` hook that refuses Bash tool calls that would leak secrets to tool output. Mandatory across the Socket fleet — every repo ships this file byte-for-byte via `scripts/sync-scaffolding.mjs`.
+
+## What it blocks
+
+| Rule | Example | Fix |
+|------|---------|-----|
+| Literal token in command | `echo vtwn_abc123…` | Rotate the exposed token; read tokens from `.env.local` at spawn time, never inline them |
+| `env`/`printenv`/`export -p`/`set` dumping everything | `env \| grep FOO` (unredacted) | `env \| sed 's/=.*/=<redacted>/'` or filter specific keys |
+| `.env*` read without redactor | `cat .env.local` | `sed 's/=.*/=<redacted>/' .env.local` or `grep -v '^#' .env.local \| cut -d= -f1` |
+| `curl -H "Authorization:"` with unfiltered stdout | `curl -H "Authorization: Bearer $TOKEN" api.example.com` | Redirect to file/`/dev/null`, or pipe to `jq`/`grep`/`head`/`wc`/`cut`/`awk` |
+| References sensitive env var name writing unredacted to stdout | `echo $API_KEY` | Same as above |
+
+## What it allows
+
+- Any write to a file (`>`, `>>`, `tee`)
+- Any pipe through `jq`, `grep`, `head`, `tail`, `wc`, `cut`, `awk`, `sed s/=.*/=<redacted>/`, `python3 -m json.tool`
+- Legitimate `git`/`pnpm`/`npm`/`node`/`tsc`/`oxfmt`/`oxlint` invocations that happen to reference env var names but don't echo values
+- Any curl call that does not carry an `Authorization:` header
+
+## Detected token shapes
+
+Literal value patterns caught in-command:
+
+- Val Town — `vtwn_`
+- Linear — `lin_api_`
+- OpenAI / Anthropic — `sk-` (20+ chars)
+- Stripe — `sk_live_`, `sk_test_`, `pk_live_`, `rk_live_`
+- GitHub — `ghp_`, `gho_`, `ghs_`, `ghu_`, `ghr_`, `github_pat_`
+- GitLab — `glpat-`
+- AWS — `AKIA…`
+- Slack — `xoxb-`, `xoxa-`, `xoxp-`, `xoxr-`, `xoxs-`
+- Google — `AIza…`
+- JWTs — three-segment `eyJ…`
+
+## Control flow
+
+The hook reads the tool-use payload from stdin, type-checks `tool_name === 'Bash'`, and runs `check(command)`. Any rule violation `throw`s a typed `BlockError`; a single top-level `try/catch` in `main()` writes the block message to stderr and sets `process.exitCode = 2`. Hook bugs fail **open** — a crash in the hook writes a log line and returns exit 0 so legitimate work isn't blocked on a bad deploy.
+
+## Testing
+
+```bash
+pnpm --filter @socketsecurity/hook-token-guard test
+```
+
+Adding new token-shape detections: update `LITERAL_TOKEN_PATTERNS` in `index.mts`, add a positive and negative test in `test/token-guard.test.mts`.
+
+## Updating across the fleet
+
+This file is in `IDENTICAL_FILES` in `scripts/sync-scaffolding.mjs`. After editing, run from `socket-repo-template`:
+
+```bash
+node scripts/sync-scaffolding.mjs --all --fix
+```
+
+to propagate the change to every fleet repo.

--- a/.claude/hooks/token-guard/index.mts
+++ b/.claude/hooks/token-guard/index.mts
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Claude Code PreToolUse hook — token-guard firewall.
+//
+// Blocks Bash commands that would echo token-bearing env vars into
+// tool output. This fires BEFORE the command runs; exit code 2 makes
+// Claude Code refuse the tool call. The model sees the rejection
+// reason on stderr and retries with a redacted formulation.
+//
+// Blocked patterns:
+//   - Literal token shapes in the command string (vtwn_, lin_api_,
+//     sk-, ghp_, AKIA, xox, AIza, JWT, etc.) — hardest block, logs
+//     a redacted message and urges rotation
+//   - `env`, `printenv`, `export -p`, `set` with no filter pipeline
+//   - `cat` / `head` / `tail` / `less` / `more` of .env* files
+//     without a redaction step
+//   - `curl -H "Authorization: ..."` with output going to unfiltered
+//     stdout (not /dev/null, not a file, not piped to jq/grep/etc.)
+//   - Commands referencing a sensitive env var name (*TOKEN*,
+//     *SECRET*, *PASSWORD*, *API_KEY*, *SIGNING_KEY*, *PRIVATE_KEY*,
+//     *AUTH*, *CREDENTIAL*) that write to stdout without redaction
+//
+// Control flow uses a `BlockError` thrown from check helpers so every
+// short-circuit path goes through a single `process.exitCode = 2`
+// drop at the top-level catch — no scattered `process.exit(2)` that
+// can race with buffered stderr.
+
+import process from 'node:process'
+
+// Name fragments matched case-insensitively against the command.
+const SENSITIVE_ENV_NAMES = [
+  'TOKEN',
+  'SECRET',
+  'PASSWORD',
+  'PASS',
+  'API_KEY',
+  'APIKEY',
+  'SIGNING_KEY',
+  'PRIVATE_KEY',
+  'AUTH',
+  'CREDENTIAL',
+]
+
+// Pipelines that "launder" earlier-stage secrets into safe output.
+const REDACTION_MARKERS = [
+  /\bsed\b[^|]*s[/|#][^/|#]*=[^/|#]*<?redact/i,
+  /\bsed\b[^|]*s[/|#][^/|#]*[A-Z_]+=[^/|#]*\*+/i,
+  /\|\s*cut\b[^|]*-d['"]?=['"]?\s*-f\s*1/i,
+  /\|\s*awk\b[^|]*-F\s*['"]?=['"]?/i,
+  />\s*\/dev\/null/,
+  />>\s*[^|]/,
+  />\s*[^|]/,
+]
+
+// Commands that dump all env vars to stdout with no filter.
+const ALWAYS_DANGEROUS = [
+  /^\s*env\s*(?:\||&&|;|$)/,
+  /^\s*env\s*$/,
+  /^\s*printenv\s*(?:\||&&|;|$)/,
+  /^\s*printenv\s*$/,
+  /^\s*export\s+-p\s*(?:\||&&|;|$)/,
+  /^\s*set\s*(?:\||&&|;|$)/,
+]
+
+// Plain reads of .env files that would dump values to stdout.
+const ENV_FILE_READ = /\b(?:cat|head|tail|less|more|bat)\b[^|]*\.env[^/\s|]*/
+
+// curl calls that include an Authorization header.
+const CURL_WITH_AUTH =
+  /\bcurl\b(?:[^|]|\|(?!\s*(?:sed|grep|head|tail|jq)))*(?:-H|--header)\s*['"]?Authorization:/i
+
+// Literal token-shape patterns — if any match in the command string,
+// a real token has been pasted somewhere it shouldn't have been.
+const LITERAL_TOKEN_PATTERNS: Array<[RegExp, string]> = [
+  [/\bvtwn_[A-Za-z0-9_-]{8,}/, 'Val Town token (vtwn_)'],
+  [/\blin_api_[A-Za-z0-9_-]{8,}/, 'Linear API token (lin_api_)'],
+  [/\bsk-[A-Za-z0-9_-]{20,}/, 'OpenAI/Anthropic-style secret key (sk-)'],
+  [/\bsk_live_[A-Za-z0-9_-]{16,}/, 'Stripe live secret (sk_live_)'],
+  [/\bsk_test_[A-Za-z0-9_-]{16,}/, 'Stripe test secret (sk_test_)'],
+  [/\bpk_live_[A-Za-z0-9_-]{16,}/, 'Stripe live publishable (pk_live_)'],
+  [/\brk_live_[A-Za-z0-9_-]{16,}/, 'Stripe live restricted (rk_live_)'],
+  [/\bghp_[A-Za-z0-9]{30,}/, 'GitHub personal access token (ghp_)'],
+  [/\bgho_[A-Za-z0-9]{30,}/, 'GitHub OAuth token (gho_)'],
+  [/\bghs_[A-Za-z0-9]{30,}/, 'GitHub app server token (ghs_)'],
+  [/\bghu_[A-Za-z0-9]{30,}/, 'GitHub user access token (ghu_)'],
+  [/\bghr_[A-Za-z0-9]{30,}/, 'GitHub refresh token (ghr_)'],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}/, 'GitHub fine-grained PAT'],
+  [/\bglpat-[A-Za-z0-9_-]{16,}/, 'GitLab PAT (glpat-)'],
+  [/\bAKIA[0-9A-Z]{16}/, 'AWS access key ID (AKIA)'],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/, 'Slack token (xox_-)'],
+  [/\bAIza[0-9A-Za-z_-]{35}/, 'Google API key (AIza)'],
+  [/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/, 'JWT'],
+]
+
+class BlockError extends Error {
+  public readonly rule: string
+  public readonly suggestion: string
+  public readonly showCommand: boolean
+  constructor(rule: string, suggestion: string, showCommand = true) {
+    super(rule)
+    this.name = 'BlockError'
+    this.rule = rule
+    this.suggestion = suggestion
+    this.showCommand = showCommand
+  }
+}
+
+const stdin = (): Promise<string> =>
+  new Promise(resolve => {
+    let buf = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', chunk => (buf += chunk))
+    process.stdin.on('end', () => resolve(buf))
+  })
+
+type ToolInput = {
+  tool_name?: string
+  tool_input?: { command?: string }
+}
+
+const hasRedaction = (command: string): boolean =>
+  REDACTION_MARKERS.some(re => re.test(command))
+
+const referencesSensitiveEnv = (command: string): boolean => {
+  const upper = command.toUpperCase()
+  return SENSITIVE_ENV_NAMES.some(frag => upper.includes(frag))
+}
+
+const matchesAlwaysDangerous = (command: string): RegExp | null => {
+  for (const re of ALWAYS_DANGEROUS) {
+    if (re.test(command)) {
+      return re
+    }
+  }
+  return null
+}
+
+const check = (command: string): void => {
+  // 0. Literal token-shape in the command string — hardest block.
+  // A real token value already landed in the command, which itself is
+  // logged. We refuse to echo it further and urge rotation.
+  for (const [pattern, label] of LITERAL_TOKEN_PATTERNS) {
+    if (pattern.test(command)) {
+      throw new BlockError(
+        `literal ${label} found in command string`,
+        'Rotate the exposed token immediately. Never paste tokens into commands; read them from .env.local or a keychain at subprocess spawn time.',
+        false,
+      )
+    }
+  }
+
+  // 1. Always-dangerous patterns.
+  const dangerous = matchesAlwaysDangerous(command)
+  if (dangerous) {
+    throw new BlockError(
+      `\`${dangerous.source}\` dumps env to stdout`,
+      'Pipe through redaction, e.g. `env | sed "s/=.*/=<redacted>/"` or filter specific keys.',
+    )
+  }
+
+  // 2. .env file reads without redaction.
+  if (ENV_FILE_READ.test(command) && !hasRedaction(command)) {
+    throw new BlockError(
+      '.env file read without a redaction pipeline',
+      'Use `sed "s/=.*/=<redacted>/" .env.local` or `grep -v "^#" .env.local | cut -d= -f1` for key names only.',
+    )
+  }
+
+  // 3. curl with Authorization header and unsanitized stdout.
+  const curlHasAuth = CURL_WITH_AUTH.test(command)
+  const curlOutputSafe =
+    />\s*\/dev\/null|>\s*[^|&]/.test(command) ||
+    /\|\s*(?:jq|grep|head|tail|wc|cut|awk|python3?\s+-m\s+json\.tool)\b/.test(
+      command,
+    )
+  if (curlHasAuth && !curlOutputSafe) {
+    throw new BlockError(
+      'curl with Authorization header and unsanitized stdout',
+      'Redirect response to /dev/null, pipe to jq/grep/head, or save to a file.',
+    )
+  }
+
+  // 4. References a sensitive env var name and writes to stdout
+  // without a redaction step. Skip when curl-with-auth passed — that
+  // rule already evaluated the same pipeline.
+  if (
+    !curlHasAuth &&
+    referencesSensitiveEnv(command) &&
+    !hasRedaction(command)
+  ) {
+    const isPureWrite = /^\s*(?:git|pnpm|npm|node|tsc|oxfmt|oxlint)\b/.test(
+      command,
+    )
+    if (!isPureWrite) {
+      throw new BlockError(
+        'command references sensitive env var name and writes to stdout without redaction',
+        'Redirect to a file, pipe through `sed "s/=.*/=<redacted>/"`, or ensure only key names (not values) are printed.',
+      )
+    }
+  }
+}
+
+const emitBlock = (command: string, err: BlockError): void => {
+  const safeCommand = err.showCommand
+    ? command.slice(0, 200) + (command.length > 200 ? '…' : '')
+    : '<command suppressed to avoid re-logging the literal token>'
+  process.stderr.write(
+    `\n[token-guard] Blocked: ${err.rule}\n` +
+      `  Command: ${safeCommand}\n` +
+      `  Fix: ${err.suggestion}\n\n`,
+  )
+}
+
+const main = async (): Promise<void> => {
+  const raw = await stdin()
+  if (!raw) {
+    return
+  }
+  let payload: ToolInput
+  try {
+    payload = JSON.parse(raw) as ToolInput
+  } catch {
+    return
+  }
+  if (payload.tool_name !== 'Bash') {
+    return
+  }
+  const command = payload.tool_input?.command ?? ''
+  if (!command) {
+    return
+  }
+
+  try {
+    check(command)
+  } catch (e) {
+    if (e instanceof BlockError) {
+      emitBlock(command, e)
+      process.exitCode = 2
+      return
+    }
+    throw e
+  }
+}
+
+main().catch(e => {
+  // Never block a tool call due to a bug in the hook itself. Log it
+  // so we notice, but fail open.
+  process.stderr.write(`[token-guard] hook error (allowing): ${e}\n`)
+  process.exitCode = 0
+})

--- a/.claude/hooks/token-guard/package.json
+++ b/.claude/hooks/token-guard/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@socketsecurity/hook-token-guard",
+  "private": true,
+  "type": "module",
+  "main": "./index.mts",
+  "exports": {
+    ".": "./index.mts"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mts"
+  }
+}

--- a/.claude/hooks/token-guard/test/token-guard.test.mts
+++ b/.claude/hooks/token-guard/test/token-guard.test.mts
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Tests for the token-guard hook.
+ *
+ * Runs the hook as a subprocess (node --test), piping a tool-use
+ * payload on stdin and asserting on the exit code + stderr. Exit 2
+ * means the hook refused the command; exit 0 means it passed it
+ * through.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { whichSync } from '@socketsecurity/lib/bin'
+import { spawnSync } from '@socketsecurity/lib/spawn'
+
+const hookScript = new URL('../index.mts', import.meta.url).pathname
+const nodeBin = whichSync('node')
+if (!nodeBin) {
+  throw new Error('"node" not found on PATH')
+}
+
+function runHook(command: string, toolName = 'Bash'): {
+  code: number | null
+  stdout: string
+  stderr: string
+} {
+  const input = JSON.stringify({
+    tool_name: toolName,
+    tool_input: { command },
+  })
+  const result = spawnSync(nodeBin, [hookScript], {
+    input,
+    timeout: 5_000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  return {
+    code: result.status,
+    stdout: (result.stdout || '').toString(),
+    stderr: (result.stderr || '').toString(),
+  }
+}
+
+describe('token-guard hook', () => {
+  describe('allows safe commands', () => {
+    it('plain echo', () => {
+      assert.equal(runHook('echo hello').code, 0)
+    })
+    it('git log', () => {
+      assert.equal(runHook('git log -1 --oneline').code, 0)
+    })
+    it('pnpm install', () => {
+      assert.equal(runHook('pnpm install').code, 0)
+    })
+    it('node script', () => {
+      assert.equal(runHook('node scripts/build.mts').code, 0)
+    })
+    it('sed with redaction on .env', () => {
+      assert.equal(
+        runHook("sed 's/=.*/=<redacted>/' .env.local").code,
+        0,
+      )
+    })
+    it('grep key-names-only on .env', () => {
+      assert.equal(
+        runHook("grep -v '^#' .env.local | cut -d= -f1").code,
+        0,
+      )
+    })
+    it('curl without Authorization header', () => {
+      assert.equal(runHook('curl -sS https://api.example.com').code, 0)
+    })
+    it('curl with auth piped to jq', () => {
+      assert.equal(
+        runHook(
+          'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com | jq .name',
+        ).code,
+        0,
+      )
+    })
+    it('curl with auth redirected to file', () => {
+      assert.equal(
+        runHook(
+          'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com > out.json',
+        ).code,
+        0,
+      )
+    })
+    it('non-Bash tool is always allowed', () => {
+      assert.equal(runHook('env', 'Edit').code, 0)
+    })
+  })
+
+  describe('blocks literal token shapes', () => {
+    it('Val Town token', () => {
+      const r = runHook('echo vtwn_ABCDEFGHIJKL')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Val Town token/)
+    })
+    it('Linear API token', () => {
+      const r = runHook('echo lin_api_ABCDEFGHIJKLMNOP')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Linear API token/)
+    })
+    it('GitHub PAT', () => {
+      const r = runHook(
+        'echo ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd1234',
+      )
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /GitHub personal access token/)
+    })
+    it('AWS access key', () => {
+      const r = runHook('echo AKIAIOSFODNN7EXAMPLE')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /AWS access key/)
+    })
+    it('Stripe test secret', () => {
+      const r = runHook('echo sk_test_ABCDEFGHIJKLMNOP')
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Stripe test secret/)
+    })
+    it('JWT', () => {
+      const r = runHook(
+        'echo eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      )
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /JWT/)
+    })
+    it('redacts the command in stderr so the literal token is not re-logged', () => {
+      const r = runHook('echo vtwn_SECRETVALUE')
+      assert.equal(r.code, 2)
+      assert.doesNotMatch(r.stderr, /SECRETVALUE/)
+      assert.match(r.stderr, /suppressed/)
+    })
+  })
+
+  describe('blocks env/printenv dumps', () => {
+    it('bare env', () => {
+      assert.equal(runHook('env').code, 2)
+    })
+    it('env piped without redactor', () => {
+      assert.equal(runHook('env | grep FOO').code, 2)
+    })
+    it('printenv', () => {
+      assert.equal(runHook('printenv').code, 2)
+    })
+    it('export -p', () => {
+      assert.equal(runHook('export -p').code, 2)
+    })
+  })
+
+  describe('blocks .env reads without redaction', () => {
+    it('cat .env.local', () => {
+      assert.equal(runHook('cat .env.local').code, 2)
+    })
+    it('head .env', () => {
+      assert.equal(runHook('head .env').code, 2)
+    })
+    it('less .env.production', () => {
+      assert.equal(runHook('less .env.production').code, 2)
+    })
+  })
+
+  describe('blocks curl with auth to unfiltered stdout', () => {
+    it('plain curl -H Authorization', () => {
+      const r = runHook(
+        'curl -sS -H "Authorization: Bearer $TOKEN" https://api.example.com',
+      )
+      assert.equal(r.code, 2)
+      assert.match(r.stderr, /Authorization header and unsanitized stdout/)
+    })
+  })
+
+  describe('blocks sensitive-env-name references without redaction', () => {
+    it('echoing $API_KEY', () => {
+      assert.equal(runHook('echo $API_KEY').code, 2)
+    })
+    it('ruby -e with $TOKEN', () => {
+      assert.equal(
+        runHook('ruby -e "puts ENV[\'ACCESS_TOKEN\']"').code,
+        2,
+      )
+    })
+  })
+
+  describe('fails open on malformed input', () => {
+    it('empty stdin', () => {
+      const r = spawnSync(nodeBin, [hookScript], {
+        input: '',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      assert.equal(r.status, 0)
+    })
+    it('non-JSON stdin', () => {
+      const r = spawnSync(nodeBin, [hookScript], {
+        input: 'not json',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      assert.equal(r.status, 0)
+    })
+    it('empty command', () => {
+      assert.equal(runHook('').code, 0)
+    })
+  })
+})

--- a/.claude/hooks/token-guard/tsconfig.json
+++ b/.claude/hooks/token-guard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declarationMap": false,
+    "erasableSyntaxOnly": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "strict": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,23 @@
           {
             "type": "command",
             "command": "node .claude/hooks/check-new-deps/index.mts"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/path-guard/index.mts"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/token-guard/index.mts"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/public-surface-reminder/index.mts"
           }
         ]
       }

--- a/.claude/skills/_shared/path-guard-rule.md
+++ b/.claude/skills/_shared/path-guard-rule.md
@@ -1,0 +1,39 @@
+<!--
+Shared snippet — the canonical "1 path, 1 reference" rule text.
+Synced byte-identical across the Socket fleet via socket-repo-template's
+sync-scaffolding.mjs (SHARED_SKILL_FILES).
+
+This file is the source of truth for the rule's wording. Three artifacts
+embed (or paraphrase) it:
+
+  1. CLAUDE.md — every Socket repo's instructions to Claude.
+  2. .claude/hooks/path-guard/README.md — what the hook blocks.
+  3. .claude/skills/path-guard/SKILL.md — what the skill enforces.
+
+If the wording changes here, re-run `node scripts/sync-scaffolding.mjs
+--all --fix` from socket-repo-template to propagate.
+-->
+
+## 1 path, 1 reference
+
+**A path is *constructed* exactly once. Everywhere else *references* the constructed value.**
+
+Referencing a single computed path many times is fine — that's the whole point of computing it once. What's banned is *re-constructing* the same path in multiple places, because that's where drift is born. Three concrete shapes:
+
+1. **Within a package** — every script, test, and lib file that needs a build path imports it from the package's `scripts/paths.mts` (or `lib/paths.mts`). No `path.join('build', mode, ...)` outside that module.
+
+2. **Across packages** — when package B consumes package A's output, B imports A's `paths.mts` via the workspace `exports` field. Never `path.join(PKG, '..', '<sibling>', 'build', ...)`. The R28 yoga/ink bug — ink hand-building yoga's wasm path and missing the `wasm/` segment — is the canonical failure mode this rule prevents.
+
+3. **Workflows, Dockerfiles, shell scripts** — they can't `import` TS, so they construct the string once and reference it everywhere downstream. Workflows: a "Compute paths" step exposes `steps.paths.outputs.final_dir`; later steps read `${{ steps.paths.outputs.final_dir }}`. Dockerfiles/shell: assign once to a variable, reference by name thereafter. Each canonical construction carries a comment naming the source-of-truth `paths.mts` so the YAML can't drift from TS without a flagged change. **Re-building** the same path in a second step is the violation, not referring to the constructed value many times.
+
+Comments that re-state a full path are forbidden. The import statement IS the comment. Docs and READMEs may describe the structure ("output goes under the Final dir") but should not encode a complete `build/<mode>/<platform-arch>/out/Final/binary` string — encoded paths get parsed by tools and silently rot.
+
+Code execution takes priority over docs: violations in `.mts`/`.cts`, Makefiles, Dockerfiles, workflow YAML, and shell scripts are blocking. README and doc-comment violations are advisory unless they contain a fully-qualified path with no parametric placeholders.
+
+### Three-level enforcement
+
+- **Hook** — `.claude/hooks/path-guard/` blocks `Edit`/`Write` calls that would introduce a violation in a `.mts`/`.cts` file. Refusal at edit time stops new duplication from landing.
+- **Gate** — `scripts/check-paths.mts` runs in `pnpm check`. Fails the build on any violation that isn't allowlisted.
+- **Skill** — `/path-guard` audits the repo and fixes findings; `/path-guard check` reports only; `/path-guard install` drops the gate + hook + rule into a fresh repo.
+
+The mantra is intentionally short so it sticks: **1 path, 1 reference**. When in doubt, find the canonical owner and import from it.

--- a/.claude/skills/path-guard/SKILL.md
+++ b/.claude/skills/path-guard/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: path-guard
+description: Audit and fix path duplication in this Socket repo. Apply the strict "1 path, 1 reference" rule — every build/test/runtime/config path is constructed exactly once; everywhere else references the constructed value. Default mode finds and fixes; `check` mode reports only; `install` mode drops the gate + hook + rule into a fresh repo.
+user-invocable: true
+allowed-tools: Task, Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
+---
+
+# path-guard
+
+**Mantra: 1 path, 1 reference.** A path is constructed exactly once; everywhere else references the constructed value. Re-constructing the same path twice is the violation, not referencing the constructed value many times.
+
+## Modes
+
+- `/path-guard` — full audit-and-fix conversion of the current repo (default).
+- `/path-guard check` — read-only audit, report violations, no fixes.
+- `/path-guard fix <id>` — fix a single finding from a prior `check` run, by index.
+- `/path-guard install` — drop the gate + hook + rule + allowlist into a fresh repo (for new Socket repos).
+
+## Three-level enforcement
+
+The strategy lives in three artifacts that ship together:
+
+1. **CLAUDE.md rule** — the mantra and detection rules in plain language. Every Socket repo's CLAUDE.md carries `## 1 path, 1 reference`. Synced from `.claude/skills/_shared/path-guard-rule.md`.
+2. **Hook** — `.claude/hooks/path-guard/index.mts` runs `PreToolUse` on `Edit`/`Write` of `.mts`/`.cts` files. Blocks new violations at edit time. Mandatory across the fleet.
+3. **Gate** — `scripts/check-paths.mts` runs in `pnpm check` (and CI). Whole-repo scan. Fails the build on any unsanctioned violation.
+
+This skill is the *audit-and-fix workflow* that makes a repo conform initially and validates conformance over time.
+
+## Detection rules
+
+The gate enforces six rules. The hook enforces a subset (A and B) since it sees only one diff at a time.
+
+| Rule | What it catches | Where checked |
+|---|---|---|
+| **A** | Multi-stage `path.join(...)` constructed inline. Two or more "stage" segments (Final, Release, Stripped, Compressed, Optimized, Synced, wasm, downloaded), or one stage + build-root + mode. | `.mts`/`.cts` files outside a `paths.mts`. Hook + gate. |
+| **B** | Cross-package traversal: `path.join(*, '..', '<sibling-package>', 'build', ...)` reaching into a sibling's output instead of importing via `exports`. | `.mts`/`.cts` files. Hook + gate. |
+| **C** | Workflow YAML constructs the same path string in 2+ steps outside a "Compute paths" step. | `.github/workflows/*.yml`. Gate. |
+| **D** | Comment encodes a fully-qualified multi-stage path string (e.g. `# build/dev/darwin-arm64/out/Final/binary`). | `.github/workflows/*.yml`. Gate. |
+| **F** | Same path shape constructed in 2+ different files. | All scanned files. Gate. |
+| **G** | Hand-built multi-stage path constructed 2+ times in the same Makefile/Dockerfile/shell stage. | `Makefile`, `*.mk`, `*.Dockerfile`, `Dockerfile.*`, `*.sh`. Gate. |
+
+Comments may describe path *structure* with placeholders (`<mode>/<arch>` or `${BUILD_MODE}/${PLATFORM_ARCH}`) but should not encode a complete literal path string. Code execution takes priority over docs: violations in `.mts`, Makefiles, Dockerfiles, workflow YAML, shell scripts are blocking.
+
+## Mode: audit-and-fix (default)
+
+When invoked as `/path-guard` with no arg:
+
+1. **Setup** — spawn a worktree off `main` per `CLAUDE.md` parallel-sessions rule:
+   ```bash
+   git worktree add -b paths-audit ../<repo>-paths-audit main
+   cd ../<repo>-paths-audit
+   ```
+
+2. **Audit** — run the gate to enumerate findings:
+   ```bash
+   pnpm run check:paths --json > /tmp/paths-findings.json
+   pnpm run check:paths --explain   # human-readable
+   ```
+
+3. **Fix loop** — for each finding, apply the matching pattern below. After each fix, re-run the gate. Stop iterating when `pnpm run check:paths` exits 0.
+
+4. **Verify** — run the full check suite + zizmor on any modified workflow:
+   ```bash
+   pnpm check
+   for w in .github/workflows/*.yml; do zizmor "$w"; done
+   ```
+
+5. **Commit and push** — group fixes by logical category (workflows, code, Dockerfiles). Push directly to `main` for repos that allow direct push, or open a PR for repos that require it (socket-cli, socket-sdk-js, socket-registry per their CLAUDE.md / memory entries).
+
+## Fix patterns
+
+### Rule A — Multi-stage path constructed inline (in `.mts`/`.cts`)
+
+**Bad**:
+```ts
+const finalBinary = path.join(PACKAGE_ROOT, 'build', BUILD_MODE, PLATFORM_ARCH, 'out', 'Final', 'binary')
+```
+
+**Fix**: move the construction into the package's `scripts/paths.mts` (or `lib/paths.mts`), or use a build-infra helper:
+```ts
+// In packages/foo/scripts/paths.mts:
+export function getBuildPaths(mode, platformArch) {
+  // ... constructs once ...
+  return { outputFinalBinary: path.join(PACKAGE_ROOT, 'build', mode, platformArch, 'out', 'Final', binaryName) }
+}
+
+// In the consumer:
+import { getBuildPaths } from './paths.mts'
+const { outputFinalBinary } = getBuildPaths(mode, platformArch)
+```
+
+For binsuite tools (binpress/binflate/binject) the canonical helper is `getFinalBinaryPath(packageRoot, mode, platformArch, binaryName)` from `build-infra/lib/paths`. For download caches use `getDownloadedDir(packageRoot)`.
+
+### Rule B — Cross-package traversal
+
+**Bad**:
+```ts
+const liefDir = path.join(PACKAGE_ROOT, '..', 'lief-builder', 'build', mode, platformArch, 'out', 'Final', 'lief')
+```
+
+**Fix**: declare the workspace dep, expose `paths.mts` via the producer's `exports`, import the helper:
+
+1. In producer's `package.json`:
+   ```json
+   "exports": {
+     "./scripts/paths": "./scripts/paths.mts"
+   }
+   ```
+2. In consumer's `package.json` `dependencies`:
+   ```json
+   "lief-builder": "workspace:*"
+   ```
+3. In consumer:
+   ```ts
+   import { getBuildPaths as getLiefBuildPaths } from 'lief-builder/scripts/paths'
+   const { outputFinalDir } = getLiefBuildPaths(mode, platformArch)
+   ```
+
+### Rule C — Workflow path repetition
+
+**Bad** (3 steps each rebuilding the same path):
+```yaml
+- name: Step A
+  run: cd packages/foo/build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final && do-thing-1
+- name: Step B
+  run: cd packages/foo/build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final && do-thing-2
+- name: Step C
+  run: cd packages/foo/build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final && do-thing-3
+```
+
+**Fix**: add a "Compute <pkg> paths" step early in the job that constructs the path once, expose via `$GITHUB_OUTPUT`, reference downstream:
+
+```yaml
+- name: Compute foo paths
+  id: paths
+  env:
+    BUILD_MODE: ${{ steps.build-mode.outputs.mode }}
+    PLATFORM_ARCH: ${{ steps.platform-arch.outputs.platform_arch }}
+  run: |
+    PACKAGE_DIR="packages/foo"
+    PLATFORM_BUILD_DIR="${PACKAGE_DIR}/build/${BUILD_MODE}/${PLATFORM_ARCH}"
+    FINAL_DIR="${PLATFORM_BUILD_DIR}/out/Final"
+    {
+      echo "package_dir=${PACKAGE_DIR}"
+      echo "platform_build_dir=${PLATFORM_BUILD_DIR}"
+      echo "final_dir=${FINAL_DIR}"
+    } >> "$GITHUB_OUTPUT"
+
+- name: Step A
+  env:
+    FINAL_DIR: ${{ steps.paths.outputs.final_dir }}
+  run: cd "$FINAL_DIR" && do-thing-1
+# ... etc
+```
+
+For paths used inside `working-directory: packages/foo` steps, expose a `_rel` companion (e.g. `final_dir_rel=build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final`) and reference that.
+
+### Rule D — Comment-encoded paths
+
+**Bad**:
+```yaml
+# Path: packages/foo/build/dev/darwin-arm64/out/Final/binary
+COPY --from=builder /build/.../out/Final/binary /out/Final/binary
+```
+
+**Fix**: cite the canonical `paths.mts` instead of duplicating the string:
+```yaml
+# Layout owned by packages/foo/scripts/paths.mts:getBuildPaths().
+COPY --from=builder /build/packages/foo/build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final/binary /out/Final/binary
+```
+
+The comment may describe structure (`<mode>/<arch>`) but should not be a parsable literal path.
+
+### Rule G — Dockerfile/Makefile/shell duplicate construction
+
+**Bad** (Dockerfile reconstructs the path 3 times in the same stage):
+```dockerfile
+RUN mkdir -p build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final && \
+    cp src build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final/output && \
+    ls build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final/
+```
+
+**Fix**: declare an `ENV` once, reference everywhere:
+```dockerfile
+# Layout owned by packages/foo/scripts/paths.mts.
+ENV FINAL_DIR=build/${BUILD_MODE}/${PLATFORM_ARCH}/out/Final
+RUN mkdir -p "$FINAL_DIR" && cp src "$FINAL_DIR/output" && ls "$FINAL_DIR/"
+```
+
+Each Dockerfile `FROM` stage is its own scope — ENV from the build stage doesn't reach a subsequent `FROM scratch AS export` stage. The gate accounts for this.
+
+## Mode: check (read-only)
+
+When invoked as `/path-guard check`:
+
+```bash
+pnpm run check:paths --explain
+```
+
+Print the gate's findings without making any edits. Exit 0 if clean, 1 if findings present. Useful for CI / pre-merge inspection.
+
+## Mode: install (new repo)
+
+When invoked as `/path-guard install` on a Socket repo that doesn't yet have the gate:
+
+1. Copy the gate file from this skill's reference dir:
+   ```bash
+   cp .claude/skills/path-guard/reference/check-paths.mts.tmpl scripts/check-paths.mts
+   ```
+2. Copy the empty allowlist:
+   ```bash
+   cp .claude/skills/path-guard/reference/paths-allowlist.yml.tmpl .github/paths-allowlist.yml
+   ```
+3. Add `"check:paths": "node scripts/check-paths.mts"` to `package.json`.
+4. Wire `runPathHygieneCheck()` into `scripts/check.mts` (after the existing checks).
+5. Append the rule snippet from `.claude/skills/_shared/path-guard-rule.md` to the repo's `CLAUDE.md` if a `1 path, 1 reference` section is missing.
+6. Add the hook entry to `.claude/settings.json` `PreToolUse` matcher `Edit|Write`:
+   ```json
+   { "type": "command", "command": "node .claude/hooks/path-guard/index.mts" }
+   ```
+7. Run the gate against the repo. Triage findings as you would in audit-and-fix mode.
+
+## Tie-in with quality-scan
+
+The `/quality-scan` skill should call `pnpm run check:paths --json` as one of its sub-scans and surface findings as part of its A-F graded report. Failures roll into the overall quality grade. The full audit-and-fix workflow lives here; quality-scan just *detects* during periodic scans.
+
+## Reference patterns
+
+When converting a repo to the strategy, the patterns I keep reusing:
+
+- **TS-first packages**: each package owns a `scripts/paths.mts` with `PACKAGE_ROOT`, `BUILD_ROOT`, `getBuildPaths(mode, platformArch)` returning at minimum `outputFinalDir` and `outputFinalBinary`/`outputFinalFile`.
+- **Cross-package consumers**: `package.json` `exports` whitelists `./scripts/paths`. Consumer adds `"<producer>: workspace:*"` and imports.
+- **Workflows**: each job has a "Compute <pkg> paths" step (`id: paths`) early in the job. Step outputs include `package_dir`, `platform_build_dir`, `final_dir`, named files. `_rel` companions when `working-directory:` is used.
+- **Docker stages**: each `FROM` stage declares `ENV PLATFORM_BUILD_DIR=...` and `ENV FINAL_DIR=...` once. Subsequent RUN steps reference the variables.
+
+The first repo (socket-btm) is the worked example. Read its `scripts/paths.mts` files and `.github/workflows/*.yml` for canonical patterns when applying the strategy elsewhere.

--- a/.claude/skills/path-guard/reference/check-paths.mts.tmpl
+++ b/.claude/skills/path-guard/reference/check-paths.mts.tmpl
@@ -1,0 +1,764 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Path-hygiene gate.
+ *
+ * Mantra: 1 path, 1 reference. A path is constructed exactly once;
+ * everywhere else references the constructed value.
+ *
+ * Whole-repo scan complementing the per-edit `.claude/hooks/path-guard`
+ * hook. The hook stops new violations from landing; this gate finds
+ * the existing ones and blocks merges that introduce more.
+ *
+ * Rules enforced:
+ *
+ *   A — Multi-stage path constructed inline. A `path.join(...)` call
+ *       (or template literal) in a `.mts`/`.cts` file outside a
+ *       `paths.mts` that stitches together two or more "stage"
+ *       segments (Final, Release, Stripped, Compressed, Optimized,
+ *       Synced, wasm, downloaded), or one stage plus a build-root
+ *       (`build`/`out`) plus a mode (`dev`/`prod`/`shared`). The
+ *       construction belongs in the package's `paths.mts` (or a
+ *       build-infra helper); every consumer imports the computed
+ *       value.
+ *
+ *   B — Cross-package path traversal. A `path.join(*, '..', '<sibling
+ *       package>', 'build', ...)` reaches into a sibling's build
+ *       output without going through its `exports`. The sibling owns
+ *       its layout; consumers declare a workspace dep and import the
+ *       sibling's `paths.mts`.
+ *
+ *   C — Hand-built workflow path. A `.github/workflows/*.yml` step
+ *       constructs `build/${...}/out/<stage>/...` inline outside a
+ *       canonical "Compute paths" step. Workflows can carry path
+ *       strings, but the strings are constructed once and exposed via
+ *       step outputs / job env that downstream steps reference.
+ *
+ *   D — Comment-encoded paths. Comments (in code or YAML) that re-state
+ *       a fully-qualified multi-stage path. Comments may describe the
+ *       structure ("Final dir" or "build/<mode>/...") but should not
+ *       encode a complete path string that a tool would parse — the
+ *       canonical construction IS the documentation.
+ *
+ *   F — Same path constructed in multiple places. The same shape of
+ *       multi-stage `path.join(...)` (or workflow `build/${...}/...`
+ *       string template) appearing in two or more files. Construct
+ *       once and import; references of the constructed value are
+ *       unlimited.
+ *
+ *   G — Hand-built paths in Makefiles, Dockerfiles, and shell scripts.
+ *       Same shape as A, applied to executable artifacts that don't
+ *       run TypeScript. Each canonical construction must carry a
+ *       comment naming the source-of-truth `paths.mts` so the script
+ *       can't drift from TS without a flagged change.
+ *
+ * Allowlist: `.github/paths-allowlist.yml`. Each entry needs a
+ * `reason` so the list stays audit-able. Patterns are deliberately
+ * narrow — entries should be specific, not blanket.
+ *
+ * Usage:
+ *   node scripts/check-paths.mts             # default: report + fail
+ *   node scripts/check-paths.mts --explain   # long-form explanation
+ *   node scripts/check-paths.mts --json      # machine-readable
+ *   node scripts/check-paths.mts --quiet     # silent on clean
+ *
+ * Exit codes:
+ *   0 — clean (no findings, or every finding is allowlisted)
+ *   1 — findings present
+ *   2 — gate itself crashed
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+import { fileURLToPath } from 'node:url'
+
+import { parseArgs } from 'node:util'
+
+// Plain stderr/stdout output — no @socketsecurity/lib dependency so
+// the gate is self-contained and works in socket-lib itself (which
+// would otherwise import itself).
+const logger = {
+  log: (msg: string) => process.stdout.write(msg + '\n'),
+  error: (msg: string) => process.stderr.write(msg + '\n'),
+  step: (msg: string) => process.stdout.write(`→ ${msg}\n`),
+  success: (msg: string) => process.stdout.write(`✔ ${msg}\n`),
+  substep: (msg: string) => process.stdout.write(`  ${msg}\n`),
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '..')
+
+// Stage segments (Rule A core). Spreading any two of these via
+// `path.join` is a finding outside `paths.mts`.
+const STAGE_SEGMENTS = new Set([
+  'Final',
+  'Release',
+  'Stripped',
+  'Compressed',
+  'Optimized',
+  'Synced',
+  'wasm',
+  'downloaded',
+])
+
+const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
+const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
+
+// Sibling fleet packages (Rule B). Union of all packages across the
+// Socket fleet — the gate is byte-identical via sync-scaffolding, so
+// listing every fleet package keeps Rule B firing in any repo. When
+// a new package joins the workspace, add it here and propagate via
+// `node scripts/sync-scaffolding.mjs --all --fix` from
+// socket-repo-template.
+const KNOWN_SIBLING_PACKAGES = new Set([
+  // socket-btm
+  'binflate',
+  'binject',
+  'binpress',
+  'bin-infra',
+  'build-infra',
+  'codet5-models-builder',
+  'curl-builder',
+  'iocraft-builder',
+  'ink-builder',
+  'libpq-builder',
+  'lief-builder',
+  'minilm-builder',
+  'models',
+  'napi-go',
+  'node-smol-builder',
+  'onnxruntime-builder',
+  'opentui-builder',
+  'stubs-builder',
+  'ultraviolet-builder',
+  'yoga-layout-builder',
+  // socket-cli
+  'cli',
+  'package-builder',
+  // socket-tui
+  'core',
+  'react',
+  'renderer',
+  'ultraviolet',
+  'yoga',
+  // socket-registry / ultrathink
+  'acorn',
+  'npm',
+])
+
+// File-path patterns that legitimately enumerate path segments.
+const EXEMPT_FILE_PATTERNS: RegExp[] = [
+  // Any paths.mts is the canonical constructor.
+  /(^|\/)paths\.(mts|cts|js)$/,
+  // Build-infra owns shared helpers that enumerate stages.
+  /packages\/build-infra\/lib\/paths\.mts$/,
+  /packages\/build-infra\/lib\/constants\.mts$/,
+  // Path-scanning gates that intentionally enumerate.
+  /scripts\/check-paths\.mts$/,
+  /scripts\/check-consistency\.mts$/,
+  /\.claude\/hooks\/path-guard\//,
+  // Allowlist + config files.
+  /\.github\/paths-allowlist\.yml$/,
+]
+
+type Finding = {
+  rule: 'A' | 'B' | 'C' | 'D' | 'F' | 'G'
+  file: string
+  line: number
+  snippet: string
+  message: string
+  fix: string
+}
+
+const findings: Finding[] = []
+
+const args = parseArgs({
+  options: {
+    explain: { type: 'boolean', default: false },
+    json: { type: 'boolean', default: false },
+    quiet: { type: 'boolean', default: false },
+  },
+  strict: false,
+})
+
+const isExempt = (filePath: string): boolean =>
+  EXEMPT_FILE_PATTERNS.some(re => re.test(filePath))
+
+// ──────────────────────────────────────────────────────────────────
+// Allowlist loading
+// ──────────────────────────────────────────────────────────────────
+
+type AllowlistEntry = {
+  file?: string
+  pattern?: string
+  rule?: string
+  line?: number
+  reason: string
+}
+
+const loadAllowlist = (): AllowlistEntry[] => {
+  const allowlistPath = path.join(REPO_ROOT, '.github', 'paths-allowlist.yml')
+  if (!existsSync(allowlistPath)) {
+    return []
+  }
+  const text = readFileSync(allowlistPath, 'utf8')
+  // Tiny YAML parser — only the shape we need: list of entries with
+  // `file`, `pattern`, `rule`, `line`, `reason` scalar fields.
+  // Avoids a yaml dep for a gate that has to be self-contained.
+  const entries: AllowlistEntry[] = []
+  let current: Partial<AllowlistEntry> | null = null
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/\r$/, '')
+    if (!line.trim() || line.trim().startsWith('#')) {
+      continue
+    }
+    if (line.startsWith('- ')) {
+      if (current && current.reason) {
+        entries.push(current as AllowlistEntry)
+      }
+      current = {}
+      const rest = line.slice(2).trim()
+      if (rest) {
+        const m = rest.match(/^(\w+):\s*(.*)$/)
+        if (m) {
+          ;(current as any)[m[1]!] = unquote(m[2]!)
+        }
+      }
+    } else if (current) {
+      const m = line.match(/^\s+(\w+):\s*(.*)$/)
+      if (m) {
+        const key = m[1]!
+        const value = unquote(m[2]!)
+        ;(current as any)[key] =
+          key === 'line' ? Number(value) : value
+      }
+    }
+  }
+  if (current && current.reason) {
+    entries.push(current as AllowlistEntry)
+  }
+  return entries
+}
+
+const unquote = (s: string): string => {
+  const t = s.trim()
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1)
+  }
+  return t
+}
+
+const ALLOWLIST = loadAllowlist()
+
+const isAllowlisted = (finding: Finding): boolean =>
+  ALLOWLIST.some(entry => {
+    if (entry.rule && entry.rule !== finding.rule) {
+      return false
+    }
+    if (entry.file && !finding.file.includes(entry.file)) {
+      return false
+    }
+    if (entry.pattern && !finding.snippet.includes(entry.pattern)) {
+      return false
+    }
+    if (
+      entry.line !== undefined &&
+      Math.abs(entry.line - finding.line) > 2
+    ) {
+      return false
+    }
+    return true
+  })
+
+// ──────────────────────────────────────────────────────────────────
+// File walking
+// ──────────────────────────────────────────────────────────────────
+
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'build',
+  'dist',
+  'out',
+  'target',
+  '.cache',
+  'upstream',
+])
+
+const walk = function* (
+  dir: string,
+  filter: (relPath: string) => boolean,
+): Generator<string> {
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) {
+      continue
+    }
+    const full = path.join(dir, e.name)
+    const rel = path.relative(REPO_ROOT, full)
+    if (e.isDirectory()) {
+      yield* walk(full, filter)
+    } else if (e.isFile() && filter(rel)) {
+      yield rel
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule A + B: code scan (.mts / .cts)
+// ──────────────────────────────────────────────────────────────────
+
+const PATH_JOIN_RE = /\bpath\.join\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/g
+const STRING_LITERAL_RE = /(['"])((?:\\.|(?!\1)[^\\])*)\1/g
+
+const extractStringLiterals = (args: string): string[] => {
+  const literals: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = STRING_LITERAL_RE.exec(args)) !== null) {
+    if (match[2] !== undefined) {
+      literals.push(match[2])
+    }
+  }
+  return literals
+}
+
+const scanCodeFile = (relPath: string): void => {
+  const full = path.join(REPO_ROOT, relPath)
+  let content: string
+  try {
+    content = readFileSync(full, 'utf8')
+  } catch {
+    return
+  }
+  const lines = content.split('\n')
+  // Build a line-offset map so we can map regex offsets back to line
+  // numbers cheaply.
+  const lineOffsets: number[] = [0]
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '\n') {
+      lineOffsets.push(i + 1)
+    }
+  }
+  const offsetToLine = (offset: number): number => {
+    let lo = 0
+    let hi = lineOffsets.length - 1
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >>> 1
+      if (lineOffsets[mid]! <= offset) {
+        lo = mid
+      } else {
+        hi = mid - 1
+      }
+    }
+    return lo + 1
+  }
+
+  let match: RegExpExecArray | null
+  PATH_JOIN_RE.lastIndex = 0
+  while ((match = PATH_JOIN_RE.exec(content)) !== null) {
+    const callOffset = match.index
+    const argList = match[1] ?? ''
+    const literals = extractStringLiterals(argList)
+    const stages = literals.filter(l => STAGE_SEGMENTS.has(l))
+    const buildRoots = literals.filter(l => BUILD_ROOT_SEGMENTS.has(l))
+    const modes = literals.filter(l => MODE_SEGMENTS.has(l))
+
+    // Rule A: 2+ stages OR (1 stage + 1 build-root + 1 mode).
+    const triggersA =
+      stages.length >= 2 ||
+      (stages.length >= 1 && buildRoots.length >= 1 && modes.length >= 1)
+    if (triggersA) {
+      const line = offsetToLine(callOffset)
+      const snippet = (lines[line - 1] ?? '').trim()
+      findings.push({
+        rule: 'A',
+        file: relPath,
+        line,
+        snippet,
+        message:
+          'Multi-stage path constructed inline (outside paths.mts).',
+        fix: 'Construct in the owning paths.mts (or use getFinalBinaryPath / getDownloadedDir from build-infra/lib/paths). Import the computed value here.',
+      })
+    }
+
+    // Rule B: '..' followed by a known sibling package + build context.
+    let sawDotDot = false
+    for (const lit of literals) {
+      if (lit === '..') {
+        sawDotDot = true
+        continue
+      }
+      if (sawDotDot && KNOWN_SIBLING_PACKAGES.has(lit)) {
+        const hasBuildContext = literals.some(
+          l => BUILD_ROOT_SEGMENTS.has(l) || STAGE_SEGMENTS.has(l),
+        )
+        if (hasBuildContext) {
+          const line = offsetToLine(callOffset)
+          const snippet = (lines[line - 1] ?? '').trim()
+          findings.push({
+            rule: 'B',
+            file: relPath,
+            line,
+            snippet,
+            message: `Cross-package traversal into '${lit}' build output.`,
+            fix: `Add '${lit}: workspace:*' as a dep, declare an exports entry on '${lit}' (e.g. './scripts/paths' → './scripts/paths.mts'), and import the path from there.`,
+          })
+        }
+      }
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule C + D: workflow YAML scan
+// ──────────────────────────────────────────────────────────────────
+
+const WORKFLOW_PATH_RE =
+  /build\/\$\{[^}]+\}\/[^"'`\s]*\/out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/g
+const WORKFLOW_GH_EXPR_PATH_RE =
+  /build\/\$\{\{\s*[^}]+\}\}\/[^"'`\s]*\/out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/g
+
+const isInsideComputePathsBlock = (
+  lines: string[],
+  lineIdx: number,
+): boolean => {
+  // Walk backwards up to 60 lines looking for the start of the
+  // current step. If that step is a "Compute paths" step, the line
+  // is exempt.
+  for (let i = lineIdx; i >= Math.max(0, lineIdx - 60); i--) {
+    const l = lines[i] ?? ''
+    if (/^\s*-\s*name:/i.test(l)) {
+      // Step boundary — check if THIS step is a Compute paths step.
+      // The step body may include `id: paths` even if the name is
+      // something else (e.g. `id: stub-paths`), so look at the next
+      // ~20 lines for either marker.
+      for (let j = i; j < Math.min(lines.length, i + 20); j++) {
+        const m = lines[j] ?? ''
+        if (
+          /^\s*-\s*name:\s*Compute\s+[\w-]+\s+paths/i.test(m) ||
+          /^\s*id:\s*[\w-]*paths\s*$/i.test(m)
+        ) {
+          return true
+        }
+        if (j > i && /^\s*-\s*name:/i.test(m)) {
+          // Hit the next step — current step is NOT Compute paths.
+          return false
+        }
+      }
+      return false
+    }
+  }
+  return false
+}
+
+const scanWorkflowFile = (relPath: string): void => {
+  const full = path.join(REPO_ROOT, relPath)
+  let content: string
+  try {
+    content = readFileSync(full, 'utf8')
+  } catch {
+    return
+  }
+  const lines = content.split('\n')
+
+  // First pass: collect every hand-built path occurrence outside a
+  // "Compute paths" step. Per the mantra, a single reference is fine
+  // — what's banned is reconstructing the same path 2+ times.
+  type PathHit = {
+    line: number
+    snippet: string
+    pathStr: string
+  }
+  const occurrences = new Map<string, PathHit[]>()
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (/^\s*#/.test(line)) {
+      // Skip comment lines from C scan; they're under D below.
+      continue
+    }
+    if (isInsideComputePathsBlock(lines, i)) {
+      // Inside the canonical construction step — exempt.
+      continue
+    }
+    WORKFLOW_PATH_RE.lastIndex = 0
+    WORKFLOW_GH_EXPR_PATH_RE.lastIndex = 0
+    const matches: string[] = []
+    let m: RegExpExecArray | null
+    while ((m = WORKFLOW_PATH_RE.exec(line)) !== null) {
+      matches.push(m[0])
+    }
+    while ((m = WORKFLOW_GH_EXPR_PATH_RE.exec(line)) !== null) {
+      matches.push(m[0])
+    }
+    for (const pathStr of matches) {
+      const list = occurrences.get(pathStr) ?? []
+      list.push({ line: i + 1, snippet: line.trim(), pathStr })
+      occurrences.set(pathStr, list)
+    }
+  }
+
+  // Flag every occurrence of a shape that appears 2+ times.
+  for (const [pathStr, hits] of occurrences) {
+    if (hits.length < 2) {
+      continue
+    }
+    for (const hit of hits) {
+      findings.push({
+        rule: 'C',
+        file: relPath,
+        line: hit.line,
+        snippet: hit.snippet,
+        message: `Workflow constructs the same path ${hits.length} times: ${pathStr}`,
+        fix: 'Add a "Compute <pkg> paths" step (id: paths) early in the job that computes this path ONCE and exposes it via $GITHUB_OUTPUT. Reference as ${{ steps.paths.outputs.<name> }} in subsequent steps. References of the constructed value are unlimited; reconstructing is the violation.',
+      })
+    }
+  }
+
+  // Rule D: comments encoding a fully-qualified multi-stage path
+  // (separate scan since it has different semantics).
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (!/^\s*#/.test(line)) {
+      continue
+    }
+    const literalShape =
+      /build\/(?:dev|prod|shared)\/[a-z0-9-]+\/(?:wasm\/)?out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/i
+    if (literalShape.test(line)) {
+      findings.push({
+        rule: 'D',
+        file: relPath,
+        line: i + 1,
+        snippet: line.trim(),
+        message: 'Comment encodes a fully-qualified path string.',
+        fix: 'Cite the canonical paths.mts (e.g. "see packages/<pkg>/scripts/paths.mts:getBuildPaths()") instead of duplicating the path string. Comments may describe structure with placeholders ("<mode>/<arch>") but should not be a parsable path.',
+      })
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule G: Makefile / Dockerfile / shell scan
+// ──────────────────────────────────────────────────────────────────
+
+const SCRIPT_HAND_BUILT_RE =
+  /build\/\$?\{?(?:BUILD_MODE|MODE|prod|dev)\}?\/[\w${}.-]*\/out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/g
+
+const scanScriptFile = (relPath: string): void => {
+  const full = path.join(REPO_ROOT, relPath)
+  let content: string
+  try {
+    content = readFileSync(full, 'utf8')
+  } catch {
+    return
+  }
+  const lines = content.split('\n')
+  const isDockerfile =
+    /Dockerfile/i.test(relPath) || /\.glibc$|\.musl$/.test(relPath)
+
+  // First pass: collect every multi-stage path occurrence in this file,
+  // scoped per Dockerfile stage (each `FROM ... AS ...` starts a new
+  // scope where ENV/ARG don't propagate).
+  type Hit = { line: number; text: string; pathStr: string; stage: number }
+  const hits: Hit[] = []
+  let stage = 0
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (/^\s*#/.test(line)) {
+      // Skip comments — documentation, not construction.
+      continue
+    }
+    if (isDockerfile && /^FROM\s+/i.test(line)) {
+      stage += 1
+      continue
+    }
+    SCRIPT_HAND_BUILT_RE.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = SCRIPT_HAND_BUILT_RE.exec(line)) !== null) {
+      hits.push({
+        line: i + 1,
+        text: line.trim(),
+        pathStr: m[0],
+        stage,
+      })
+    }
+  }
+
+  // Group by (stage, pathStr) — only flag when a path is built 2+
+  // times within the SAME Dockerfile stage (or anywhere in non-
+  // Dockerfile scripts, where stages don't apply).
+  const grouped = new Map<string, Hit[]>()
+  for (const h of hits) {
+    const key = `${h.stage}::${h.pathStr}`
+    const list = grouped.get(key) ?? []
+    list.push(h)
+    grouped.set(key, list)
+  }
+  for (const [, list] of grouped) {
+    if (list.length < 2) {
+      continue
+    }
+    for (const hit of list) {
+      findings.push({
+        rule: 'G',
+        file: relPath,
+        line: hit.line,
+        snippet: hit.text,
+        message: `Hand-built multi-stage path constructed ${list.length} times in this file: ${hit.pathStr}`,
+        fix: 'Assign to a variable / ENV once near the top of the script / Dockerfile stage, with a comment naming the canonical paths.mts. Reference the variable everywhere downstream. References of a single construction are unlimited; reconstructing the same path is the violation.',
+      })
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule F: cross-file path repetition
+// ──────────────────────────────────────────────────────────────────
+
+const checkRuleF = (): void => {
+  // A path is "constructed" each time we see a new path.join with a
+  // matching shape. Group findings of Rule A by their snippet shape;
+  // when the same shape appears in 2+ files, demote them to Rule F so
+  // the message is more accurate.
+  const byShape = new Map<string, Finding[]>()
+  for (const f of findings) {
+    if (f.rule !== 'A') {
+      continue
+    }
+    // Normalize: strip whitespace, identifiers, surrounding context;
+    // keep just the literal path-segment shape.
+    const literalsRe = /'[^']*'|"[^"]*"/g
+    const literals = (f.snippet.match(literalsRe) ?? []).join(',')
+    if (!literals) {
+      continue
+    }
+    const list = byShape.get(literals) ?? []
+    list.push(f)
+    byShape.set(literals, list)
+  }
+  for (const [shape, list] of byShape) {
+    if (list.length < 2) {
+      continue
+    }
+    // Promote each Rule-A finding in this group to Rule F so the
+    // message tells the reader the issue is cross-file repetition,
+    // not just a single hand-build.
+    for (const f of list) {
+      f.rule = 'F'
+      f.message = `Same path shape constructed in ${list.length} places: ${shape.slice(0, 100)}`
+      f.fix =
+        'Construct this path ONCE in a paths.mts (or build-infra helper) and import the computed value. References of the computed variable are unlimited; re-constructing the same shape twice is the violation.'
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────
+
+const main = (): number => {
+  // Scan code files (Rule A + B).
+  for (const rel of walk(
+    REPO_ROOT,
+    p => p.endsWith('.mts') || p.endsWith('.cts'),
+  )) {
+    if (isExempt(rel)) {
+      continue
+    }
+    scanCodeFile(rel)
+  }
+  // Scan workflows (Rule C + D).
+  const workflowDir = path.join(REPO_ROOT, '.github', 'workflows')
+  if (existsSync(workflowDir)) {
+    for (const rel of walk(workflowDir, p => p.endsWith('.yml'))) {
+      if (isExempt(rel)) {
+        continue
+      }
+      scanWorkflowFile(rel)
+    }
+  }
+  // Scan scripts/Makefiles/Dockerfiles (Rule G).
+  for (const rel of walk(REPO_ROOT, p => {
+    const base = path.basename(p)
+    return (
+      base === 'Makefile' ||
+      base.endsWith('.mk') ||
+      base.endsWith('.Dockerfile') ||
+      base === 'Dockerfile' ||
+      base.endsWith('.glibc') ||
+      base.endsWith('.musl') ||
+      (base.endsWith('.sh') && !p.includes('test/'))
+    )
+  })) {
+    if (isExempt(rel)) {
+      continue
+    }
+    scanScriptFile(rel)
+  }
+  // Promote cross-file Rule-A repeats to Rule F.
+  checkRuleF()
+
+  // Filter against allowlist.
+  const blocking = findings.filter(f => !isAllowlisted(f))
+
+  if (args.values.json) {
+    process.stdout.write(
+      JSON.stringify(
+        { findings: blocking, allowlisted: findings.length - blocking.length },
+        null,
+        2,
+      ) + '\n',
+    )
+    return blocking.length === 0 ? 0 : 1
+  }
+
+  if (blocking.length === 0) {
+    if (!args.values.quiet) {
+      logger.success('Path-hygiene check passed (1 path, 1 reference)')
+      if (findings.length > 0) {
+        logger.substep(`${findings.length} finding(s) allowlisted`)
+      }
+    }
+    return 0
+  }
+
+  logger.error(
+    `Path-hygiene check FAILED — ${blocking.length} finding(s)`,
+  )
+  logger.log('')
+  logger.log('Mantra: 1 path, 1 reference')
+  logger.log('')
+  for (const f of blocking) {
+    logger.log(`  [${f.rule}] ${f.file}:${f.line}`)
+    logger.log(`      ${f.snippet}`)
+    logger.log(`      → ${f.message}`)
+    if (args.values.explain) {
+      logger.log(`      Fix: ${f.fix}`)
+    }
+    logger.log('')
+  }
+  if (!args.values.explain) {
+    logger.log('Run with --explain to see fix suggestions per finding.')
+    logger.log(
+      'Add intentional exceptions to .github/paths-allowlist.yml with a `reason` field.',
+    )
+  }
+  return 1
+}
+
+try {
+  process.exitCode = main()
+} catch (e) {
+  logger.error(`Path-hygiene gate crashed: ${e}`)
+  process.exitCode = 2
+}

--- a/.claude/skills/path-guard/reference/claude-md-rule.md
+++ b/.claude/skills/path-guard/reference/claude-md-rule.md
@@ -1,0 +1,29 @@
+<!--
+This file is the rule snippet that goes into every Socket repo's CLAUDE.md
+(or the equivalent canonical instructions file). It mirrors
+.claude/skills/_shared/path-guard-rule.md byte-for-byte; keep them in sync.
+-->
+
+## 1 path, 1 reference
+
+**A path is *constructed* exactly once. Everywhere else *references* the constructed value.**
+
+Referencing a single computed path many times is fine — that's the whole point of computing it once. What's banned is *re-constructing* the same path in multiple places, because that's where drift is born.
+
+Three concrete shapes:
+
+1. **Within a package** — every script, test, and lib file that needs a build path imports it from the package's `scripts/paths.mts` (or `lib/paths.mts`). No `path.join('build', mode, ...)` outside that module.
+
+2. **Across packages** — when package B consumes package A's output, B imports A's `paths.mts` via the workspace `exports` field. Never `path.join(PKG, '..', '<sibling>', 'build', ...)`. The R28 yoga/ink bug — ink hand-building yoga's wasm path and missing the `wasm/` segment — is the canonical failure mode this rule prevents.
+
+3. **Workflows, Dockerfiles, shell scripts** — they can't `import` TS, so they construct the string once and reference it everywhere downstream. Workflows: a "Compute paths" step exposes `steps.paths.outputs.final_dir`; later steps read `${{ steps.paths.outputs.final_dir }}`. Dockerfiles/shell: assign once to a variable / `ENV`, reference by name thereafter. Each canonical construction carries a comment naming the source-of-truth `paths.mts`. **Re-building** the same path in a second step is the violation, not referring to the constructed value many times.
+
+Comments may describe path *structure* with placeholders ("`<mode>/<arch>`" or "`${BUILD_MODE}/${PLATFORM_ARCH}`") but should not encode a complete literal path string. Code execution takes priority over docs: violations in `.mts`/`.cts`, Makefiles, Dockerfiles, workflow YAML, and shell scripts are blocking. README and doc-comment violations are advisory unless they contain a fully-qualified path with no parametric placeholders.
+
+### Three-level enforcement
+
+- **Hook** — `.claude/hooks/path-guard/` blocks `Edit`/`Write` calls that would introduce a violation in a `.mts`/`.cts` file. Refusal at edit time stops new duplication from landing.
+- **Gate** — `scripts/check-paths.mts` runs in `pnpm check`. Fails the build on any violation that isn't allowlisted in `.github/paths-allowlist.yml`.
+- **Skill** — `/path-guard` audits the repo and fixes findings; `/path-guard check` reports only; `/path-guard install` drops the gate + hook + rule into a fresh repo.
+
+The mantra is intentionally short so it sticks: **1 path, 1 reference**. When in doubt, find the canonical owner and import from it.

--- a/.claude/skills/path-guard/reference/paths-allowlist.yml.tmpl
+++ b/.claude/skills/path-guard/reference/paths-allowlist.yml.tmpl
@@ -1,0 +1,28 @@
+# Path-hygiene gate allowlist.
+# Mantra: 1 path, 1 reference.
+#
+# Each entry exempts a specific finding from `scripts/check-paths.mts`.
+# Entries MUST carry a `reason` so the list stays audit-able and
+# entries can be removed when the underlying code changes.
+#
+# Schema (all top-level keys optional except `reason`):
+#
+#   - rule:    Rule letter (A, B, C, D, F, G). Omit to match any rule.
+#     file:    Substring match against the relative file path.
+#     pattern: Substring match against the offending snippet.
+#     line:    Line number; matches if within ±2 of the finding.
+#     reason:  Why this site is genuinely exempt. Required.
+#
+# Prefer narrow entries (rule + file + line + pattern) over blanket
+# `file:` entries that exempt the whole file. Genuine exemptions are
+# rare — most "false positives" should be reported as gate bugs.
+#
+# Example:
+#
+#   - rule: A
+#     file: packages/foo/scripts/legacy-build.mts
+#     line: 42
+#     pattern: "path.join(testDir, 'out', 'Final')"
+#     reason: |
+#       legacy-build.mts is scheduled for removal in v2.0; refactoring
+#       its path construction now would conflict with the rewrite.

--- a/.github/paths-allowlist.yml
+++ b/.github/paths-allowlist.yml
@@ -1,0 +1,30 @@
+# Path-hygiene gate allowlist.
+# Mantra: 1 path, 1 reference.
+#
+# Each entry exempts a specific finding from `scripts/check-paths.mts`.
+# Entries MUST carry a `reason` so the list stays audit-able and
+# entries can be removed when the underlying code changes.
+#
+# Schema (all top-level keys optional except `reason`):
+#
+#   - rule:    Rule letter (A, B, C, D, F, G). Omit to match any rule.
+#     file:    Substring match against the relative file path.
+#     pattern: Substring match against the offending snippet.
+#     line:    Line number; matches if within ±2 of the finding.
+#     reason:  Why this site is genuinely exempt. Required.
+#
+# Prefer narrow entries (rule + file + line + pattern) over blanket
+# `file:` entries that exempt the whole file. Genuine exemptions are
+# rare — most "false positives" should be reported as gate bugs.
+#
+# Example:
+#
+#   - rule: A
+#     file: packages/foo/scripts/legacy-build.mts
+#     line: 42
+#     pattern: "path.join(testDir, 'out', 'Final')"
+#     reason: |
+#       legacy-build.mts is scheduled for removal in v2.0; refactoring
+#       its path construction now would conflict with the rewrite.
+
+# (No allowlist entries yet — socket-btm is meant to be clean.)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "node scripts/build.mts",
     "check": "node scripts/check.mts",
     "check-trusted": "node scripts/npm/check-trusted-packages.mts",
+    "check:paths": "node scripts/check-paths.mts",
     "clean": "node scripts/clean.mts",
     "cover": "node scripts/cover.mts",
     "fix": "node scripts/fix.mts",

--- a/scripts/check-paths.mts
+++ b/scripts/check-paths.mts
@@ -1,0 +1,764 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Path-hygiene gate.
+ *
+ * Mantra: 1 path, 1 reference. A path is constructed exactly once;
+ * everywhere else references the constructed value.
+ *
+ * Whole-repo scan complementing the per-edit `.claude/hooks/path-guard`
+ * hook. The hook stops new violations from landing; this gate finds
+ * the existing ones and blocks merges that introduce more.
+ *
+ * Rules enforced:
+ *
+ *   A — Multi-stage path constructed inline. A `path.join(...)` call
+ *       (or template literal) in a `.mts`/`.cts` file outside a
+ *       `paths.mts` that stitches together two or more "stage"
+ *       segments (Final, Release, Stripped, Compressed, Optimized,
+ *       Synced, wasm, downloaded), or one stage plus a build-root
+ *       (`build`/`out`) plus a mode (`dev`/`prod`/`shared`). The
+ *       construction belongs in the package's `paths.mts` (or a
+ *       build-infra helper); every consumer imports the computed
+ *       value.
+ *
+ *   B — Cross-package path traversal. A `path.join(*, '..', '<sibling
+ *       package>', 'build', ...)` reaches into a sibling's build
+ *       output without going through its `exports`. The sibling owns
+ *       its layout; consumers declare a workspace dep and import the
+ *       sibling's `paths.mts`.
+ *
+ *   C — Hand-built workflow path. A `.github/workflows/*.yml` step
+ *       constructs `build/${...}/out/<stage>/...` inline outside a
+ *       canonical "Compute paths" step. Workflows can carry path
+ *       strings, but the strings are constructed once and exposed via
+ *       step outputs / job env that downstream steps reference.
+ *
+ *   D — Comment-encoded paths. Comments (in code or YAML) that re-state
+ *       a fully-qualified multi-stage path. Comments may describe the
+ *       structure ("Final dir" or "build/<mode>/...") but should not
+ *       encode a complete path string that a tool would parse — the
+ *       canonical construction IS the documentation.
+ *
+ *   F — Same path constructed in multiple places. The same shape of
+ *       multi-stage `path.join(...)` (or workflow `build/${...}/...`
+ *       string template) appearing in two or more files. Construct
+ *       once and import; references of the constructed value are
+ *       unlimited.
+ *
+ *   G — Hand-built paths in Makefiles, Dockerfiles, and shell scripts.
+ *       Same shape as A, applied to executable artifacts that don't
+ *       run TypeScript. Each canonical construction must carry a
+ *       comment naming the source-of-truth `paths.mts` so the script
+ *       can't drift from TS without a flagged change.
+ *
+ * Allowlist: `.github/paths-allowlist.yml`. Each entry needs a
+ * `reason` so the list stays audit-able. Patterns are deliberately
+ * narrow — entries should be specific, not blanket.
+ *
+ * Usage:
+ *   node scripts/check-paths.mts             # default: report + fail
+ *   node scripts/check-paths.mts --explain   # long-form explanation
+ *   node scripts/check-paths.mts --json      # machine-readable
+ *   node scripts/check-paths.mts --quiet     # silent on clean
+ *
+ * Exit codes:
+ *   0 — clean (no findings, or every finding is allowlisted)
+ *   1 — findings present
+ *   2 — gate itself crashed
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+import { fileURLToPath } from 'node:url'
+
+import { parseArgs } from 'node:util'
+
+// Plain stderr/stdout output — no @socketsecurity/lib dependency so
+// the gate is self-contained and works in socket-lib itself (which
+// would otherwise import itself).
+const logger = {
+  log: (msg: string) => process.stdout.write(msg + '\n'),
+  error: (msg: string) => process.stderr.write(msg + '\n'),
+  step: (msg: string) => process.stdout.write(`→ ${msg}\n`),
+  success: (msg: string) => process.stdout.write(`✔ ${msg}\n`),
+  substep: (msg: string) => process.stdout.write(`  ${msg}\n`),
+}
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '..')
+
+// Stage segments (Rule A core). Spreading any two of these via
+// `path.join` is a finding outside `paths.mts`.
+const STAGE_SEGMENTS = new Set([
+  'Final',
+  'Release',
+  'Stripped',
+  'Compressed',
+  'Optimized',
+  'Synced',
+  'wasm',
+  'downloaded',
+])
+
+const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
+const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
+
+// Sibling fleet packages (Rule B). Union of all packages across the
+// Socket fleet — the gate is byte-identical via sync-scaffolding, so
+// listing every fleet package keeps Rule B firing in any repo. When
+// a new package joins the workspace, add it here and propagate via
+// `node scripts/sync-scaffolding.mjs --all --fix` from
+// socket-repo-template.
+const KNOWN_SIBLING_PACKAGES = new Set([
+  // socket-btm
+  'binflate',
+  'binject',
+  'binpress',
+  'bin-infra',
+  'build-infra',
+  'codet5-models-builder',
+  'curl-builder',
+  'iocraft-builder',
+  'ink-builder',
+  'libpq-builder',
+  'lief-builder',
+  'minilm-builder',
+  'models',
+  'napi-go',
+  'node-smol-builder',
+  'onnxruntime-builder',
+  'opentui-builder',
+  'stubs-builder',
+  'ultraviolet-builder',
+  'yoga-layout-builder',
+  // socket-cli
+  'cli',
+  'package-builder',
+  // socket-tui
+  'core',
+  'react',
+  'renderer',
+  'ultraviolet',
+  'yoga',
+  // socket-registry / ultrathink
+  'acorn',
+  'npm',
+])
+
+// File-path patterns that legitimately enumerate path segments.
+const EXEMPT_FILE_PATTERNS: RegExp[] = [
+  // Any paths.mts is the canonical constructor.
+  /(^|\/)paths\.(mts|cts|js)$/,
+  // Build-infra owns shared helpers that enumerate stages.
+  /packages\/build-infra\/lib\/paths\.mts$/,
+  /packages\/build-infra\/lib\/constants\.mts$/,
+  // Path-scanning gates that intentionally enumerate.
+  /scripts\/check-paths\.mts$/,
+  /scripts\/check-consistency\.mts$/,
+  /\.claude\/hooks\/path-guard\//,
+  // Allowlist + config files.
+  /\.github\/paths-allowlist\.yml$/,
+]
+
+type Finding = {
+  rule: 'A' | 'B' | 'C' | 'D' | 'F' | 'G'
+  file: string
+  line: number
+  snippet: string
+  message: string
+  fix: string
+}
+
+const findings: Finding[] = []
+
+const args = parseArgs({
+  options: {
+    explain: { type: 'boolean', default: false },
+    json: { type: 'boolean', default: false },
+    quiet: { type: 'boolean', default: false },
+  },
+  strict: false,
+})
+
+const isExempt = (filePath: string): boolean =>
+  EXEMPT_FILE_PATTERNS.some(re => re.test(filePath))
+
+// ──────────────────────────────────────────────────────────────────
+// Allowlist loading
+// ──────────────────────────────────────────────────────────────────
+
+type AllowlistEntry = {
+  file?: string
+  pattern?: string
+  rule?: string
+  line?: number
+  reason: string
+}
+
+const loadAllowlist = (): AllowlistEntry[] => {
+  const allowlistPath = path.join(REPO_ROOT, '.github', 'paths-allowlist.yml')
+  if (!existsSync(allowlistPath)) {
+    return []
+  }
+  const text = readFileSync(allowlistPath, 'utf8')
+  // Tiny YAML parser — only the shape we need: list of entries with
+  // `file`, `pattern`, `rule`, `line`, `reason` scalar fields.
+  // Avoids a yaml dep for a gate that has to be self-contained.
+  const entries: AllowlistEntry[] = []
+  let current: Partial<AllowlistEntry> | null = null
+  for (const raw of text.split('\n')) {
+    const line = raw.replace(/\r$/, '')
+    if (!line.trim() || line.trim().startsWith('#')) {
+      continue
+    }
+    if (line.startsWith('- ')) {
+      if (current && current.reason) {
+        entries.push(current as AllowlistEntry)
+      }
+      current = {}
+      const rest = line.slice(2).trim()
+      if (rest) {
+        const m = rest.match(/^(\w+):\s*(.*)$/)
+        if (m) {
+          ;(current as any)[m[1]!] = unquote(m[2]!)
+        }
+      }
+    } else if (current) {
+      const m = line.match(/^\s+(\w+):\s*(.*)$/)
+      if (m) {
+        const key = m[1]!
+        const value = unquote(m[2]!)
+        ;(current as any)[key] =
+          key === 'line' ? Number(value) : value
+      }
+    }
+  }
+  if (current && current.reason) {
+    entries.push(current as AllowlistEntry)
+  }
+  return entries
+}
+
+const unquote = (s: string): string => {
+  const t = s.trim()
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1)
+  }
+  return t
+}
+
+const ALLOWLIST = loadAllowlist()
+
+const isAllowlisted = (finding: Finding): boolean =>
+  ALLOWLIST.some(entry => {
+    if (entry.rule && entry.rule !== finding.rule) {
+      return false
+    }
+    if (entry.file && !finding.file.includes(entry.file)) {
+      return false
+    }
+    if (entry.pattern && !finding.snippet.includes(entry.pattern)) {
+      return false
+    }
+    if (
+      entry.line !== undefined &&
+      Math.abs(entry.line - finding.line) > 2
+    ) {
+      return false
+    }
+    return true
+  })
+
+// ──────────────────────────────────────────────────────────────────
+// File walking
+// ──────────────────────────────────────────────────────────────────
+
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'build',
+  'dist',
+  'out',
+  'target',
+  '.cache',
+  'upstream',
+])
+
+const walk = function* (
+  dir: string,
+  filter: (relPath: string) => boolean,
+): Generator<string> {
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const e of entries) {
+    if (SKIP_DIRS.has(e.name)) {
+      continue
+    }
+    const full = path.join(dir, e.name)
+    const rel = path.relative(REPO_ROOT, full)
+    if (e.isDirectory()) {
+      yield* walk(full, filter)
+    } else if (e.isFile() && filter(rel)) {
+      yield rel
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule A + B: code scan (.mts / .cts)
+// ──────────────────────────────────────────────────────────────────
+
+const PATH_JOIN_RE = /\bpath\.join\s*\(\s*([^()]*(?:\([^()]*\)[^()]*)*)\)/g
+const STRING_LITERAL_RE = /(['"])((?:\\.|(?!\1)[^\\])*)\1/g
+
+const extractStringLiterals = (args: string): string[] => {
+  const literals: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = STRING_LITERAL_RE.exec(args)) !== null) {
+    if (match[2] !== undefined) {
+      literals.push(match[2])
+    }
+  }
+  return literals
+}
+
+const scanCodeFile = (relPath: string): void => {
+  const full = path.join(REPO_ROOT, relPath)
+  let content: string
+  try {
+    content = readFileSync(full, 'utf8')
+  } catch {
+    return
+  }
+  const lines = content.split('\n')
+  // Build a line-offset map so we can map regex offsets back to line
+  // numbers cheaply.
+  const lineOffsets: number[] = [0]
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === '\n') {
+      lineOffsets.push(i + 1)
+    }
+  }
+  const offsetToLine = (offset: number): number => {
+    let lo = 0
+    let hi = lineOffsets.length - 1
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >>> 1
+      if (lineOffsets[mid]! <= offset) {
+        lo = mid
+      } else {
+        hi = mid - 1
+      }
+    }
+    return lo + 1
+  }
+
+  let match: RegExpExecArray | null
+  PATH_JOIN_RE.lastIndex = 0
+  while ((match = PATH_JOIN_RE.exec(content)) !== null) {
+    const callOffset = match.index
+    const argList = match[1] ?? ''
+    const literals = extractStringLiterals(argList)
+    const stages = literals.filter(l => STAGE_SEGMENTS.has(l))
+    const buildRoots = literals.filter(l => BUILD_ROOT_SEGMENTS.has(l))
+    const modes = literals.filter(l => MODE_SEGMENTS.has(l))
+
+    // Rule A: 2+ stages OR (1 stage + 1 build-root + 1 mode).
+    const triggersA =
+      stages.length >= 2 ||
+      (stages.length >= 1 && buildRoots.length >= 1 && modes.length >= 1)
+    if (triggersA) {
+      const line = offsetToLine(callOffset)
+      const snippet = (lines[line - 1] ?? '').trim()
+      findings.push({
+        rule: 'A',
+        file: relPath,
+        line,
+        snippet,
+        message:
+          'Multi-stage path constructed inline (outside paths.mts).',
+        fix: 'Construct in the owning paths.mts (or use getFinalBinaryPath / getDownloadedDir from build-infra/lib/paths). Import the computed value here.',
+      })
+    }
+
+    // Rule B: '..' followed by a known sibling package + build context.
+    let sawDotDot = false
+    for (const lit of literals) {
+      if (lit === '..') {
+        sawDotDot = true
+        continue
+      }
+      if (sawDotDot && KNOWN_SIBLING_PACKAGES.has(lit)) {
+        const hasBuildContext = literals.some(
+          l => BUILD_ROOT_SEGMENTS.has(l) || STAGE_SEGMENTS.has(l),
+        )
+        if (hasBuildContext) {
+          const line = offsetToLine(callOffset)
+          const snippet = (lines[line - 1] ?? '').trim()
+          findings.push({
+            rule: 'B',
+            file: relPath,
+            line,
+            snippet,
+            message: `Cross-package traversal into '${lit}' build output.`,
+            fix: `Add '${lit}: workspace:*' as a dep, declare an exports entry on '${lit}' (e.g. './scripts/paths' → './scripts/paths.mts'), and import the path from there.`,
+          })
+        }
+      }
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule C + D: workflow YAML scan
+// ──────────────────────────────────────────────────────────────────
+
+const WORKFLOW_PATH_RE =
+  /build\/\$\{[^}]+\}\/[^"'`\s]*\/out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/g
+const WORKFLOW_GH_EXPR_PATH_RE =
+  /build\/\$\{\{\s*[^}]+\}\}\/[^"'`\s]*\/out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/g
+
+const isInsideComputePathsBlock = (
+  lines: string[],
+  lineIdx: number,
+): boolean => {
+  // Walk backwards up to 60 lines looking for the start of the
+  // current step. If that step is a "Compute paths" step, the line
+  // is exempt.
+  for (let i = lineIdx; i >= Math.max(0, lineIdx - 60); i--) {
+    const l = lines[i] ?? ''
+    if (/^\s*-\s*name:/i.test(l)) {
+      // Step boundary — check if THIS step is a Compute paths step.
+      // The step body may include `id: paths` even if the name is
+      // something else (e.g. `id: stub-paths`), so look at the next
+      // ~20 lines for either marker.
+      for (let j = i; j < Math.min(lines.length, i + 20); j++) {
+        const m = lines[j] ?? ''
+        if (
+          /^\s*-\s*name:\s*Compute\s+[\w-]+\s+paths/i.test(m) ||
+          /^\s*id:\s*[\w-]*paths\s*$/i.test(m)
+        ) {
+          return true
+        }
+        if (j > i && /^\s*-\s*name:/i.test(m)) {
+          // Hit the next step — current step is NOT Compute paths.
+          return false
+        }
+      }
+      return false
+    }
+  }
+  return false
+}
+
+const scanWorkflowFile = (relPath: string): void => {
+  const full = path.join(REPO_ROOT, relPath)
+  let content: string
+  try {
+    content = readFileSync(full, 'utf8')
+  } catch {
+    return
+  }
+  const lines = content.split('\n')
+
+  // First pass: collect every hand-built path occurrence outside a
+  // "Compute paths" step. Per the mantra, a single reference is fine
+  // — what's banned is reconstructing the same path 2+ times.
+  type PathHit = {
+    line: number
+    snippet: string
+    pathStr: string
+  }
+  const occurrences = new Map<string, PathHit[]>()
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (/^\s*#/.test(line)) {
+      // Skip comment lines from C scan; they're under D below.
+      continue
+    }
+    if (isInsideComputePathsBlock(lines, i)) {
+      // Inside the canonical construction step — exempt.
+      continue
+    }
+    WORKFLOW_PATH_RE.lastIndex = 0
+    WORKFLOW_GH_EXPR_PATH_RE.lastIndex = 0
+    const matches: string[] = []
+    let m: RegExpExecArray | null
+    while ((m = WORKFLOW_PATH_RE.exec(line)) !== null) {
+      matches.push(m[0])
+    }
+    while ((m = WORKFLOW_GH_EXPR_PATH_RE.exec(line)) !== null) {
+      matches.push(m[0])
+    }
+    for (const pathStr of matches) {
+      const list = occurrences.get(pathStr) ?? []
+      list.push({ line: i + 1, snippet: line.trim(), pathStr })
+      occurrences.set(pathStr, list)
+    }
+  }
+
+  // Flag every occurrence of a shape that appears 2+ times.
+  for (const [pathStr, hits] of occurrences) {
+    if (hits.length < 2) {
+      continue
+    }
+    for (const hit of hits) {
+      findings.push({
+        rule: 'C',
+        file: relPath,
+        line: hit.line,
+        snippet: hit.snippet,
+        message: `Workflow constructs the same path ${hits.length} times: ${pathStr}`,
+        fix: 'Add a "Compute <pkg> paths" step (id: paths) early in the job that computes this path ONCE and exposes it via $GITHUB_OUTPUT. Reference as ${{ steps.paths.outputs.<name> }} in subsequent steps. References of the constructed value are unlimited; reconstructing is the violation.',
+      })
+    }
+  }
+
+  // Rule D: comments encoding a fully-qualified multi-stage path
+  // (separate scan since it has different semantics).
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (!/^\s*#/.test(line)) {
+      continue
+    }
+    const literalShape =
+      /build\/(?:dev|prod|shared)\/[a-z0-9-]+\/(?:wasm\/)?out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/i
+    if (literalShape.test(line)) {
+      findings.push({
+        rule: 'D',
+        file: relPath,
+        line: i + 1,
+        snippet: line.trim(),
+        message: 'Comment encodes a fully-qualified path string.',
+        fix: 'Cite the canonical paths.mts (e.g. "see packages/<pkg>/scripts/paths.mts:getBuildPaths()") instead of duplicating the path string. Comments may describe structure with placeholders ("<mode>/<arch>") but should not be a parsable path.',
+      })
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule G: Makefile / Dockerfile / shell scan
+// ──────────────────────────────────────────────────────────────────
+
+const SCRIPT_HAND_BUILT_RE =
+  /build\/\$?\{?(?:BUILD_MODE|MODE|prod|dev)\}?\/[\w${}.-]*\/out\/(?:Final|Release|Stripped|Compressed|Optimized|Synced)/g
+
+const scanScriptFile = (relPath: string): void => {
+  const full = path.join(REPO_ROOT, relPath)
+  let content: string
+  try {
+    content = readFileSync(full, 'utf8')
+  } catch {
+    return
+  }
+  const lines = content.split('\n')
+  const isDockerfile =
+    /Dockerfile/i.test(relPath) || /\.glibc$|\.musl$/.test(relPath)
+
+  // First pass: collect every multi-stage path occurrence in this file,
+  // scoped per Dockerfile stage (each `FROM ... AS ...` starts a new
+  // scope where ENV/ARG don't propagate).
+  type Hit = { line: number; text: string; pathStr: string; stage: number }
+  const hits: Hit[] = []
+  let stage = 0
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (/^\s*#/.test(line)) {
+      // Skip comments — documentation, not construction.
+      continue
+    }
+    if (isDockerfile && /^FROM\s+/i.test(line)) {
+      stage += 1
+      continue
+    }
+    SCRIPT_HAND_BUILT_RE.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = SCRIPT_HAND_BUILT_RE.exec(line)) !== null) {
+      hits.push({
+        line: i + 1,
+        text: line.trim(),
+        pathStr: m[0],
+        stage,
+      })
+    }
+  }
+
+  // Group by (stage, pathStr) — only flag when a path is built 2+
+  // times within the SAME Dockerfile stage (or anywhere in non-
+  // Dockerfile scripts, where stages don't apply).
+  const grouped = new Map<string, Hit[]>()
+  for (const h of hits) {
+    const key = `${h.stage}::${h.pathStr}`
+    const list = grouped.get(key) ?? []
+    list.push(h)
+    grouped.set(key, list)
+  }
+  for (const [, list] of grouped) {
+    if (list.length < 2) {
+      continue
+    }
+    for (const hit of list) {
+      findings.push({
+        rule: 'G',
+        file: relPath,
+        line: hit.line,
+        snippet: hit.text,
+        message: `Hand-built multi-stage path constructed ${list.length} times in this file: ${hit.pathStr}`,
+        fix: 'Assign to a variable / ENV once near the top of the script / Dockerfile stage, with a comment naming the canonical paths.mts. Reference the variable everywhere downstream. References of a single construction are unlimited; reconstructing the same path is the violation.',
+      })
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Rule F: cross-file path repetition
+// ──────────────────────────────────────────────────────────────────
+
+const checkRuleF = (): void => {
+  // A path is "constructed" each time we see a new path.join with a
+  // matching shape. Group findings of Rule A by their snippet shape;
+  // when the same shape appears in 2+ files, demote them to Rule F so
+  // the message is more accurate.
+  const byShape = new Map<string, Finding[]>()
+  for (const f of findings) {
+    if (f.rule !== 'A') {
+      continue
+    }
+    // Normalize: strip whitespace, identifiers, surrounding context;
+    // keep just the literal path-segment shape.
+    const literalsRe = /'[^']*'|"[^"]*"/g
+    const literals = (f.snippet.match(literalsRe) ?? []).join(',')
+    if (!literals) {
+      continue
+    }
+    const list = byShape.get(literals) ?? []
+    list.push(f)
+    byShape.set(literals, list)
+  }
+  for (const [shape, list] of byShape) {
+    if (list.length < 2) {
+      continue
+    }
+    // Promote each Rule-A finding in this group to Rule F so the
+    // message tells the reader the issue is cross-file repetition,
+    // not just a single hand-build.
+    for (const f of list) {
+      f.rule = 'F'
+      f.message = `Same path shape constructed in ${list.length} places: ${shape.slice(0, 100)}`
+      f.fix =
+        'Construct this path ONCE in a paths.mts (or build-infra helper) and import the computed value. References of the computed variable are unlimited; re-constructing the same shape twice is the violation.'
+    }
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────
+
+const main = (): number => {
+  // Scan code files (Rule A + B).
+  for (const rel of walk(
+    REPO_ROOT,
+    p => p.endsWith('.mts') || p.endsWith('.cts'),
+  )) {
+    if (isExempt(rel)) {
+      continue
+    }
+    scanCodeFile(rel)
+  }
+  // Scan workflows (Rule C + D).
+  const workflowDir = path.join(REPO_ROOT, '.github', 'workflows')
+  if (existsSync(workflowDir)) {
+    for (const rel of walk(workflowDir, p => p.endsWith('.yml'))) {
+      if (isExempt(rel)) {
+        continue
+      }
+      scanWorkflowFile(rel)
+    }
+  }
+  // Scan scripts/Makefiles/Dockerfiles (Rule G).
+  for (const rel of walk(REPO_ROOT, p => {
+    const base = path.basename(p)
+    return (
+      base === 'Makefile' ||
+      base.endsWith('.mk') ||
+      base.endsWith('.Dockerfile') ||
+      base === 'Dockerfile' ||
+      base.endsWith('.glibc') ||
+      base.endsWith('.musl') ||
+      (base.endsWith('.sh') && !p.includes('test/'))
+    )
+  })) {
+    if (isExempt(rel)) {
+      continue
+    }
+    scanScriptFile(rel)
+  }
+  // Promote cross-file Rule-A repeats to Rule F.
+  checkRuleF()
+
+  // Filter against allowlist.
+  const blocking = findings.filter(f => !isAllowlisted(f))
+
+  if (args.values.json) {
+    process.stdout.write(
+      JSON.stringify(
+        { findings: blocking, allowlisted: findings.length - blocking.length },
+        null,
+        2,
+      ) + '\n',
+    )
+    return blocking.length === 0 ? 0 : 1
+  }
+
+  if (blocking.length === 0) {
+    if (!args.values.quiet) {
+      logger.success('Path-hygiene check passed (1 path, 1 reference)')
+      if (findings.length > 0) {
+        logger.substep(`${findings.length} finding(s) allowlisted`)
+      }
+    }
+    return 0
+  }
+
+  logger.error(
+    `Path-hygiene check FAILED — ${blocking.length} finding(s)`,
+  )
+  logger.log('')
+  logger.log('Mantra: 1 path, 1 reference')
+  logger.log('')
+  for (const f of blocking) {
+    logger.log(`  [${f.rule}] ${f.file}:${f.line}`)
+    logger.log(`      ${f.snippet}`)
+    logger.log(`      → ${f.message}`)
+    if (args.values.explain) {
+      logger.log(`      Fix: ${f.fix}`)
+    }
+    logger.log('')
+  }
+  if (!args.values.explain) {
+    logger.log('Run with --explain to see fix suggestions per finding.')
+    logger.log(
+      'Add intentional exceptions to .github/paths-allowlist.yml with a `reason` field.',
+    )
+  }
+  return 1
+}
+
+try {
+  process.exitCode = main()
+} catch (e) {
+  logger.error(`Path-hygiene gate crashed: ${e}`)
+  process.exitCode = 2
+}

--- a/scripts/check.mts
+++ b/scripts/check.mts
@@ -160,6 +160,15 @@ async function main(): Promise<void> {
           shell: WIN32,
         },
       },
+      // Path-hygiene gate (1 path, 1 reference). See
+      // .claude/skills/path-guard/ + .claude/hooks/path-guard/.
+      {
+        args: ['scripts/check-paths.mts', '--quiet'],
+        command: 'node',
+        options: {
+          shell: WIN32,
+        },
+      },
     ]
 
     const exitCodes = await runParallel(checks)

--- a/scripts/xport-schema.mts
+++ b/scripts/xport-schema.mts
@@ -7,7 +7,7 @@
  *     TypeBox schema, emitted by scripts/xport-emit-schema.mts
  *   - Runtime validation at harness startup via
  *     `validateSchema(XportManifestSchema, ...)` from
- *     `@socketsecurity/lib/schema/validate`
+ *     `@socketsecurity/lib/validation/validate-schema`
  *
  * Byte-identical across socket-tui / socket-btm / socket-sdxgen / ultrathink /
  * socket-registry / socket-repo-template via sync-scaffolding.mjs.

--- a/xport.schema.json
+++ b/xport.schema.json
@@ -4,7 +4,9 @@
   "title": "xport lock-step manifest",
   "description": "Unified lock-step manifest shared across Socket repos. One schema, all cases — `kind` discriminator on each row selects which flavor of lock-step applies.",
   "type": "object",
-  "required": ["rows"],
+  "required": [
+    "rows"
+  ],
   "properties": {
     "$schema": {
       "type": "string"
@@ -30,7 +32,10 @@
         "^(.*)$": {
           "additionalProperties": false,
           "type": "object",
-          "required": ["submodule", "repo"],
+          "required": [
+            "submodule",
+            "repo"
+          ],
           "properties": {
             "submodule": {
               "description": "Submodule path, relative to repo root.",
@@ -52,7 +57,9 @@
         "^(.*)$": {
           "additionalProperties": false,
           "type": "object",
-          "required": ["path"],
+          "required": [
+            "path"
+          ],
           "properties": {
             "path": {
               "description": "Path to the port's root directory, relative to repo root.",
@@ -205,7 +212,13 @@
             "additionalProperties": false,
             "description": "A behavioral feature reimplemented locally to match upstream behavior. Three-pillar validation: code patterns, test patterns, fixture snapshots.",
             "type": "object",
-            "required": ["kind", "id", "upstream", "criticality", "local_area"],
+            "required": [
+              "kind",
+              "id",
+              "upstream",
+              "criticality",
+              "local_area"
+            ],
             "properties": {
               "kind": {
                 "const": "feature-parity",
@@ -260,7 +273,9 @@
                 "additionalProperties": false,
                 "description": "Golden-input verification. Prefer snapshot-based diffs over hardcoded counts (brittleness lesson from sdxgen's lock-step-features).",
                 "type": "object",
-                "required": ["fixture_path"],
+                "required": [
+                  "fixture_path"
+                ],
                 "properties": {
                   "fixture_path": {
                     "type": "string"
@@ -410,7 +425,9 @@
                     "additionalProperties": false,
                     "description": "Per-port status for a lang-parity row. `implemented` = port meets assertions; `opt-out` = port consciously skips, requires non-empty `reason`.",
                     "type": "object",
-                    "required": ["status"],
+                    "required": [
+                      "status"
+                    ],
                     "properties": {
                       "status": {
                         "anyOf": [


### PR DESCRIPTION
## Summary

Propagates `path-guard` infrastructure + `token-hygiene → token-guard` rename from socket-repo-template@cfba1e6.

Mantra: **1 path, 1 reference.**

Three-level enforcement: CLAUDE.md rule, hook (`Edit`/`Write` on `.mts`/`.cts`), gate (`scripts/check-paths.mts` in `pnpm check`).

## Changed

- `.claude/hooks/path-guard/` — new hook + tests
- `.claude/hooks/token-guard/` — renamed from `token-hygiene`
- `.claude/skills/path-guard/` — invokable skill
- `scripts/check-paths.mts` — the gate
- `.github/paths-allowlist.yml` — empty starter
- `.claude/settings.json` — wire path-guard on Edit|Write, token-guard on Bash
- `scripts/check.mts` — runs the gate after the existing parallel checks
- `package.json` — adds `check:paths` script

## Verification

```bash
node scripts/check-paths.mts --quiet  # exit 0 — clean
```

## Companion propagations

socket-cli #1280, socket-sdk-js #621, socket-btm 360d469d, socket-tui 79dc1ca, socket-lib 5153ddd, socket-sdxgen ef8e39f, ultrathink 1534b406d, socket-packageurl-js e720bc1.

## Test plan

- [x] gate runs clean
- [ ] CI passes