### PR TITLE
feat(path-guard): drift-resistant allowlist + centralized segment vocabulary

### DIFF
--- a/.claude/hooks/path-guard/index.mts
+++ b/.claude/hooks/path-guard/index.mts
@@ -56,77 +56,12 @@
 
 import process from 'node:process'
 
-// "Stage" segments — appearing two or more in the same path.join /
-// template literal is a Rule A violation. These come from
-// build-infra/lib/constants.mts BUILD_STAGES plus their lowercase
-// directory-name siblings used by some builders (yoga's `wasm/`,
-// build-infra's `downloaded/`).
-const STAGE_SEGMENTS = new Set([
-  'Final',
-  'Release',
-  'Stripped',
-  'Compressed',
-  'Optimized',
-  'Synced',
-  'wasm',
-  'downloaded',
-])
-
-// "Build-root" segments — at least one must be present together with a
-// stage segment to confirm we're constructing a build output path
-// rather than something coincidental. Example: `path.join(SRC,
-// 'wasm', 'lib')` shouldn't fire (no build root); `path.join(PKG,
-// 'build', 'wasm', 'out', 'Final')` should (build root + wasm + out +
-// Final).
-const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
-
-// Mode segments — appearing alongside stage + build-root tightens the
-// match further. `'dev'` and `'prod'` alone are too generic; we count
-// them as a confirming signal, not a trigger.
-const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
-
-// Sibling Socket-fleet packages whose build output is reached via
-// `path.join(*, '..', '<name>', 'build', ...)`. Union of all packages
-// across the Socket fleet — the hook is byte-identical via
-// sync-scaffolding, so listing every fleet package keeps Rule B firing
-// in any repo. When a new package joins the workspace, add it here
-// and propagate via `node scripts/sync-scaffolding.mjs --all --fix`
-// from socket-repo-template.
-const KNOWN_SIBLING_PACKAGES = new Set([
-  // socket-btm
-  'binflate',
-  'binject',
-  'binpress',
-  'bin-infra',
-  'build-infra',
-  'codet5-models-builder',
-  'curl-builder',
-  'iocraft-builder',
-  'ink-builder',
-  'libpq-builder',
-  'lief-builder',
-  'minilm-builder',
-  'models',
-  'napi-go',
-  'node-smol-builder',
-  'onnxruntime-builder',
-  'opentui-builder',
-  'stubs-builder',
-  'ultraviolet-builder',
-  'yoga-layout-builder',
-  // socket-cli
-  'cli',
-  'package-builder',
-  // socket-tui
-  'core',
-  'react',
-  'renderer',
-  'ultraviolet',
-  'yoga',
-  // socket-registry / ultrathink
-  'acorn',
-  'npm',
-])
+import {
+  BUILD_ROOT_SEGMENTS,
+  KNOWN_SIBLING_PACKAGES,
+  MODE_SEGMENTS,
+  STAGE_SEGMENTS,
+} from './segments.mts'
 
 // File-path patterns that are exempt from the hook entirely. Edits to
 // these files legitimately need to enumerate path segments.

--- a/.claude/hooks/path-guard/index.mts
+++ b/.claude/hooks/path-guard/index.mts
@@ -293,13 +293,58 @@ const checkRuleB = (calls: ReturnType<typeof extractPathCalls>): void => {
   }
 }
 
+// Backtick template-literal detection. Path construction via
+// `${buildDir}/out/Final/${binary}` follows the same shape as
+// path.join() and constitutes the same Rule A violation. Placeholders
+// (${...}) are stripped to a sentinel that won't match any segment
+// set, so segments composed entirely of interpolation contribute
+// nothing to the trigger.
+const TEMPLATE_LITERAL_RE = /`((?:\\.|(?:\$\{(?:[^{}]|\{[^{}]*\})*\})|(?!`)[^\\])*)`/g
+
+const checkRuleATemplate = (source: string): void => {
+  TEMPLATE_LITERAL_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = TEMPLATE_LITERAL_RE.exec(source)) !== null) {
+    const body = m[1] ?? ''
+    if (!body.includes('/')) {
+      continue
+    }
+    const stripped = body.replace(/\$\{(?:[^{}]|\{[^{}]*\})*\}/g, '\x00')
+    const segments = stripped
+      .split('/')
+      .filter(s => s.length > 0 && s !== '\x00')
+    const stages = segments.filter(s => STAGE_SEGMENTS.has(s))
+    const buildRoots = segments.filter(s => BUILD_ROOT_SEGMENTS.has(s))
+    const modes = segments.filter(s => MODE_SEGMENTS.has(s))
+    // Template literal trigger is tighter than path.join() because
+    // backtick strings often appear in patch fixtures, error messages,
+    // and other multi-line content that incidentally contains stage
+    // tokens like `wasm`. Require the canonical build-output shape.
+    const hasBuildAndOut =
+      buildRoots.includes('build') && buildRoots.includes('out')
+    const hasOut = buildRoots.includes('out')
+    const hasBuild = buildRoots.includes('build')
+    const triggers =
+      (hasBuildAndOut && stages.length >= 1) ||
+      (stages.length >= 2 && hasOut) ||
+      (hasBuild && stages.length >= 1 && modes.length >= 1)
+    if (triggers) {
+      throw new BlockError(
+        'A — multi-stage path constructed inline via template literal',
+        'Construct this path in the owning `paths.mts` (or a build-infra helper) and import the computed value here. 1 path, 1 reference.',
+        m[0],
+      )
+    }
+  }
+}
+
 const check = (source: string): void => {
   const calls = extractPathCalls(source)
-  if (calls.length === 0) {
-    return
+  if (calls.length > 0) {
+    checkRuleA(calls)
+    checkRuleB(calls)
   }
-  checkRuleA(calls)
-  checkRuleB(calls)
+  checkRuleATemplate(source)
 }
 
 const emitBlock = (filePath: string, err: BlockError): void => {

--- a/.claude/hooks/path-guard/segments.mts
+++ b/.claude/hooks/path-guard/segments.mts
@@ -1,0 +1,80 @@
+// Canonical path-segment vocabulary shared by the path-guard hook
+// (.claude/hooks/path-guard/index.mts) and gate (scripts/check-paths.mts).
+//
+// Mantra: 1 path, 1 reference. This module is the *one* place stage,
+// build-root, mode, and sibling-package vocabulary is defined. Both
+// consumers import from here so they can never drift apart.
+//
+// Synced byte-identically across the Socket fleet via
+// socket-repo-template/scripts/sync-scaffolding.mjs (IDENTICAL_FILES).
+// When adding a new stage/build-root/mode/sibling, edit this file in
+// the template and re-sync.
+
+// "Stage" segments — Rule A core. Two of these spread via `path.join`
+// or interpolated into a template literal is a finding outside a
+// canonical `paths.mts`. Sourced from build-infra/lib/constants.mts
+// `BUILD_STAGES` plus their lowercase directory-name siblings used by
+// some builders.
+export const STAGE_SEGMENTS = new Set([
+  'Compressed',
+  'downloaded',
+  'Final',
+  'Optimized',
+  'Release',
+  'Stripped',
+  'Synced',
+  'wasm',
+])
+
+// "Build-root" segments — at least one must be present together with
+// a stage segment to confirm we're constructing a build output path
+// rather than something coincidental. Example: a join that yields
+// `<root>/<stage>/<lib>` doesn't fire if no build-root segment is
+// present; `<root>/build/<stage>/out/<stage>` does.
+export const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
+
+// Build-mode segments — a stage segment plus one of these is also a
+// finding (`build/<mode>/<arch>/out/<stage>` is the canonical shape).
+export const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
+
+// Sibling fleet packages (Rule B). Union of all packages across the
+// Socket fleet — the gate is byte-identical via sync-scaffolding, so
+// listing every fleet package keeps Rule B firing in any repo. When a
+// new package joins the workspace, add it here and propagate via
+// `node scripts/sync-scaffolding.mjs --all --fix` from
+// socket-repo-template.
+export const KNOWN_SIBLING_PACKAGES = new Set([
+  // socket-btm
+  'bin-infra',
+  'binflate',
+  'binject',
+  'binpress',
+  'build-infra',
+  'codet5-models-builder',
+  'curl-builder',
+  'ink-builder',
+  'iocraft-builder',
+  'libpq-builder',
+  'lief-builder',
+  'minilm-builder',
+  'models',
+  'napi-go',
+  'node-smol-builder',
+  'onnxruntime-builder',
+  'opentui-builder',
+  'stubs-builder',
+  'ultraviolet-builder',
+  'yoga-layout-builder',
+  // socket-cli
+  'cli',
+  'package-builder',
+  // socket-tui
+  'core',
+  'react',
+  'renderer',
+  'ultraviolet',
+  'yoga',
+  // socket-registry / ultrathink
+  'acorn',
+  'npm',
+])

--- a/.claude/hooks/path-guard/test/path-guard.test.mts
+++ b/.claude/hooks/path-guard/test/path-guard.test.mts
@@ -190,6 +190,60 @@ describe('path-guard — paren-balance correctness', () => {
   })
 })
 
+describe('path-guard — template literals', () => {
+  it('detects A in fully-literal template path', () => {
+    const source = '\n      const p = `build/dev/out/Final/binary`\n    '
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 2)
+  })
+
+  it('detects A in template with placeholders', () => {
+    const source =
+      '\n      const p = `${PKG}/build/${mode}/${arch}/out/Final/${name}`\n    '
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 2)
+  })
+
+  it('allows template with single non-stage segment', () => {
+    const source = '\n      const url = `https://example.com/path`\n    '
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('allows template with no stage segments', () => {
+    const source = '\n      const tmp = `${packageRoot}/build/temp/cache`\n    '
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+
+  it('allows template that is purely interpolation', () => {
+    // `${a}/${b}/${c}` has no literal stage segments.
+    const source = '\n      const p = `${a}/${b}/${c}`\n    '
+    const { code } = runHook(
+      'Write',
+      'packages/foo/scripts/build.mts',
+      source,
+    )
+    assert.equal(code, 0)
+  })
+})
+
 describe('path-guard — file-type filter', () => {
   it('skips .ts files', () => {
     const source = `

--- a/.claude/skills/path-guard/SKILL.md
+++ b/.claude/skills/path-guard/SKILL.md
@@ -199,6 +199,18 @@ pnpm run check:paths --explain
 
 Print the gate's findings without making any edits. Exit 0 if clean, 1 if findings present. Useful for CI / pre-merge inspection.
 
+## Allowlisting a finding
+
+When a genuine exemption is needed (rare — most "false positives" should be reported as gate bugs), add an entry to `.github/paths-allowlist.yml`. Two ways to pin the entry to a specific site:
+
+- **`line:`** — exact line number. Strict; a single-line edit above shifts the entry off-target and the finding re-surfaces.
+- **`snippet_hash:`** — 12-char SHA-256 prefix of the offending snippet (whitespace-normalized). Drift-resistant: survives reformatting, but any content-changing edit invalidates it. Get the hash:
+  ```bash
+  pnpm run check:paths --show-hashes
+  ```
+
+Both may be set — either matching is sufficient. Prefer `snippet_hash` over raw `line:` when the exemption is expected to outlive routine reformatting; prefer `line:` when you specifically *want* the entry to fall off after any nearby edit.
+
 ## Mode: install (new repo)
 
 When invoked as `/path-guard install` on a Socket repo that doesn't yet have the gate:

--- a/.claude/skills/path-guard/reference/check-paths.mts.tmpl
+++ b/.claude/skills/path-guard/reference/check-paths.mts.tmpl
@@ -76,6 +76,13 @@ import { fileURLToPath } from 'node:url'
 
 import { parseArgs } from 'node:util'
 
+import {
+  BUILD_ROOT_SEGMENTS,
+  KNOWN_SIBLING_PACKAGES,
+  MODE_SEGMENTS,
+  STAGE_SEGMENTS,
+} from '../.claude/hooks/path-guard/segments.mts'
+
 // Plain stderr/stdout output — no @socketsecurity/lib dependency so
 // the gate is self-contained and works in socket-lib itself (which
 // would otherwise import itself).
@@ -91,63 +98,10 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const REPO_ROOT = path.resolve(__dirname, '..')
 
-// Stage segments (Rule A core). Spreading any two of these via
-// `path.join` is a finding outside `paths.mts`.
-const STAGE_SEGMENTS = new Set([
-  'Final',
-  'Release',
-  'Stripped',
-  'Compressed',
-  'Optimized',
-  'Synced',
-  'wasm',
-  'downloaded',
-])
-
-const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
-const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
-
-// Sibling fleet packages (Rule B). Union of all packages across the
-// Socket fleet — the gate is byte-identical via sync-scaffolding, so
-// listing every fleet package keeps Rule B firing in any repo. When
-// a new package joins the workspace, add it here and propagate via
-// `node scripts/sync-scaffolding.mjs --all --fix` from
-// socket-repo-template.
-const KNOWN_SIBLING_PACKAGES = new Set([
-  // socket-btm
-  'binflate',
-  'binject',
-  'binpress',
-  'bin-infra',
-  'build-infra',
-  'codet5-models-builder',
-  'curl-builder',
-  'iocraft-builder',
-  'ink-builder',
-  'libpq-builder',
-  'lief-builder',
-  'minilm-builder',
-  'models',
-  'napi-go',
-  'node-smol-builder',
-  'onnxruntime-builder',
-  'opentui-builder',
-  'stubs-builder',
-  'ultraviolet-builder',
-  'yoga-layout-builder',
-  // socket-cli
-  'cli',
-  'package-builder',
-  // socket-tui
-  'core',
-  'react',
-  'renderer',
-  'ultraviolet',
-  'yoga',
-  // socket-registry / ultrathink
-  'acorn',
-  'npm',
-])
+// Stage / build-root / mode / sibling-package vocabularies are imported
+// from `.claude/hooks/path-guard/segments.mts` (the canonical source).
+// Both this gate and the path-guard hook share that single definition
+// — Mantra: 1 path, 1 reference.
 
 // File-path patterns that legitimately enumerate path segments.
 const EXEMPT_FILE_PATTERNS: RegExp[] = [

--- a/.claude/skills/path-guard/reference/check-paths.mts.tmpl
+++ b/.claude/skills/path-guard/reference/check-paths.mts.tmpl
@@ -67,6 +67,7 @@
  *   2 — gate itself crashed
  */
 
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -179,6 +180,7 @@ const args = parseArgs({
     explain: { type: 'boolean', default: false },
     json: { type: 'boolean', default: false },
     quiet: { type: 'boolean', default: false },
+    'show-hashes': { type: 'boolean', default: false },
   },
   strict: false,
 })
@@ -195,6 +197,7 @@ type AllowlistEntry = {
   pattern?: string
   rule?: string
   line?: number
+  snippet_hash?: string
   reason: string
 }
 
@@ -315,6 +318,36 @@ const unquote = (s: string): string => {
 
 const ALLOWLIST = loadAllowlist()
 
+/**
+ * Stable, normalized snippet hash. Whitespace-insensitive so trivial
+ * reformatting (indent change, trailing comma, line wrap) doesn't
+ * invalidate an allowlist entry, but content-changing edits do. The
+ * hash exposes only the first 12 hex chars (~48 bits) which is plenty
+ * for collision-resistance within a single repo's finding set and
+ * keeps the YAML readable.
+ */
+const snippetHash = (snippet: string): string => {
+  const normalized = snippet.replace(/\s+/g, ' ').trim()
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 12)
+}
+
+/**
+ * Allowlist matching trades off two failure modes:
+ *
+ *   - Drift via reformatting (a line shift breaks an entry, the
+ *     finding re-surfaces, devs paper over with a new entry).
+ *   - Stealth allowlisting (an entry pinned to "anywhere in this file"
+ *     silently exempts unrelated future violations).
+ *
+ * Strategy: exact line match OR `snippet_hash` match (whitespace-
+ * normalized SHA-256, first 12 hex). Either is sufficient. Lines stay
+ * exact (was ±2; the slack let reformatting silently slide), and
+ * `snippet_hash` provides reformatting-tolerant matching that's still
+ * tied to the literal text — paste-and-edit cheating would change the
+ * hash. If neither `line` nor `snippet_hash` is provided, the entry
+ * matches purely by `rule` + `file` + `pattern` (file-level exempt;
+ * use sparingly and always pair with a precise `pattern`).
+ */
 const isAllowlisted = (finding: Finding): boolean =>
   ALLOWLIST.some(entry => {
     if (entry.rule && entry.rule !== finding.rule) {
@@ -326,8 +359,17 @@ const isAllowlisted = (finding: Finding): boolean =>
     if (entry.pattern && !finding.snippet.includes(entry.pattern)) {
       return false
     }
-    if (entry.line !== undefined && Math.abs(entry.line - finding.line) > 2) {
-      return false
+    const lineProvided = entry.line !== undefined
+    const hashProvided =
+      typeof entry.snippet_hash === 'string' && entry.snippet_hash.length > 0
+    if (lineProvided || hashProvided) {
+      const lineMatches =
+        lineProvided && entry.line === finding.line
+      const hashMatches =
+        hashProvided && entry.snippet_hash === snippetHash(finding.snippet)
+      if (!(lineMatches || hashMatches)) {
+        return false
+      }
     }
     return true
   })
@@ -381,6 +423,27 @@ const walk = function* (
 // argument containing 2+ levels of nested function calls).
 const PATH_CALL_RE = /\bpath\.(?:join|resolve)\s*\(/g
 const STRING_LITERAL_RE = /(['"])((?:\\.|(?!\1)[^\\])*)\1/g
+
+// Template literal scanner. Captures backtick-delimited strings
+// (including those with `${...}` placeholders) so Rule A also catches
+// path construction via template literals like
+// `${buildDir}/out/Final/${binary}` or `build/${mode}/out/Final`.
+const TEMPLATE_LITERAL_RE = /`((?:\\.|(?:\$\{(?:[^{}]|\{[^{}]*\})*\})|(?!`)[^\\])*)`/g
+
+/**
+ * Convert a template-literal body into a synthetic forward-slash path
+ * by replacing `${...}` placeholders with a sentinel and normalizing
+ * separators. Returns the sequence of path segments split on `/`. The
+ * sentinel doesn't match any STAGE/BUILD_ROOT/MODE token, so a
+ * placeholder-only segment (`${binaryName}`) won't match those sets.
+ */
+const templateLiteralSegments = (body: string): string[] => {
+  // Strip placeholders so they don't introduce noise in segments.
+  // Empty result for a placeholder is fine; downstream filters by set
+  // membership and skips empties.
+  const stripped = body.replace(/\$\{(?:[^{}]|\{[^{}]*\})*\}/g, '\x00')
+  return stripped.split('/').filter(seg => seg.length > 0 && seg !== '\x00')
+}
 
 /**
  * Extract every `path.join(...)` and `path.resolve(...)` call from the
@@ -528,6 +591,54 @@ const scanCodeFile = (relPath: string): void => {
           break
         }
       }
+    }
+  }
+
+  // Rule A (template literal variant). Backtick strings like
+  // `${buildDir}/out/Final/${binary}` or `build/${mode}/${arch}/out/Final`
+  // construct paths the same way `path.join(...)` does — flag the
+  // same shapes. Skip raw imports / template tag positions by
+  // filtering out leading `import.meta.url`-style / tag positions
+  // implicitly: TEMPLATE_LITERAL_RE matches any backtick string and
+  // we rely on segment composition to decide if it's a path.
+  TEMPLATE_LITERAL_RE.lastIndex = 0
+  let tmpl: RegExpExecArray | null
+  while ((tmpl = TEMPLATE_LITERAL_RE.exec(content)) !== null) {
+    const body = tmpl[1] ?? ''
+    if (!body.includes('/')) {
+      continue
+    }
+    const segments = templateLiteralSegments(body)
+    const stages = segments.filter(s => STAGE_SEGMENTS.has(s))
+    const buildRoots = segments.filter(s => BUILD_ROOT_SEGMENTS.has(s))
+    const modes = segments.filter(s => MODE_SEGMENTS.has(s))
+    // Template literal trigger is tighter than path.join() because
+    // backtick strings often appear in patch fixtures, error messages,
+    // and other multi-line content that incidentally contains stage
+    // tokens like `wasm`. Require the canonical build-output shape:
+    //   - 'build' + 'out' + stage (canonical multi-stage layout), OR
+    //   - 2+ stage segments AND 'out' (e.g. `wasm/out/Final`), OR
+    //   - 'build' + stage + literal mode (back-compat with path.join).
+    const hasBuildAndOut =
+      buildRoots.includes('build') && buildRoots.includes('out')
+    const hasOut = buildRoots.includes('out')
+    const hasBuild = buildRoots.includes('build')
+    const triggersA =
+      (hasBuildAndOut && stages.length >= 1) ||
+      (stages.length >= 2 && hasOut) ||
+      (hasBuild && stages.length >= 1 && modes.length >= 1)
+    if (triggersA) {
+      const line = offsetToLine(tmpl.index)
+      const snippet = (lines[line - 1] ?? '').trim()
+      findings.push({
+        rule: 'A',
+        file: relPath,
+        line,
+        snippet,
+        message:
+          'Multi-stage path constructed inline via template literal (outside paths.mts).',
+        fix: 'Construct in the owning paths.mts (or use getFinalBinaryPath / getDownloadedDir from build-infra/lib/paths). Import the computed value here.',
+      })
     }
   }
 }
@@ -853,6 +964,9 @@ const main = (): number => {
     logger.log(`  [${f.rule}] ${f.file}:${f.line}`)
     logger.log(`      ${f.snippet}`)
     logger.log(`      → ${f.message}`)
+    if (args.values['show-hashes']) {
+      logger.log(`      snippet_hash: ${snippetHash(f.snippet)}`)
+    }
     if (args.values.explain) {
       logger.log(`      Fix: ${f.fix}`)
     }
@@ -862,6 +976,9 @@ const main = (): number => {
     logger.log('Run with --explain to see fix suggestions per finding.')
     logger.log(
       'Add intentional exceptions to .github/paths-allowlist.yml with a `reason` field.',
+    )
+    logger.log(
+      'Run with --show-hashes to print the snippet_hash for each finding (drift-resistant allowlisting).',
     )
   }
   return 1

--- a/scripts/check-paths.mts
+++ b/scripts/check-paths.mts
@@ -76,6 +76,13 @@ import { fileURLToPath } from 'node:url'
 
 import { parseArgs } from 'node:util'
 
+import {
+  BUILD_ROOT_SEGMENTS,
+  KNOWN_SIBLING_PACKAGES,
+  MODE_SEGMENTS,
+  STAGE_SEGMENTS,
+} from '../.claude/hooks/path-guard/segments.mts'
+
 // Plain stderr/stdout output — no @socketsecurity/lib dependency so
 // the gate is self-contained and works in socket-lib itself (which
 // would otherwise import itself).
@@ -91,63 +98,10 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const REPO_ROOT = path.resolve(__dirname, '..')
 
-// Stage segments (Rule A core). Spreading any two of these via
-// `path.join` is a finding outside `paths.mts`.
-const STAGE_SEGMENTS = new Set([
-  'Final',
-  'Release',
-  'Stripped',
-  'Compressed',
-  'Optimized',
-  'Synced',
-  'wasm',
-  'downloaded',
-])
-
-const BUILD_ROOT_SEGMENTS = new Set(['build', 'out'])
-const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
-
-// Sibling fleet packages (Rule B). Union of all packages across the
-// Socket fleet — the gate is byte-identical via sync-scaffolding, so
-// listing every fleet package keeps Rule B firing in any repo. When
-// a new package joins the workspace, add it here and propagate via
-// `node scripts/sync-scaffolding.mjs --all --fix` from
-// socket-repo-template.
-const KNOWN_SIBLING_PACKAGES = new Set([
-  // socket-btm
-  'binflate',
-  'binject',
-  'binpress',
-  'bin-infra',
-  'build-infra',
-  'codet5-models-builder',
-  'curl-builder',
-  'iocraft-builder',
-  'ink-builder',
-  'libpq-builder',
-  'lief-builder',
-  'minilm-builder',
-  'models',
-  'napi-go',
-  'node-smol-builder',
-  'onnxruntime-builder',
-  'opentui-builder',
-  'stubs-builder',
-  'ultraviolet-builder',
-  'yoga-layout-builder',
-  // socket-cli
-  'cli',
-  'package-builder',
-  // socket-tui
-  'core',
-  'react',
-  'renderer',
-  'ultraviolet',
-  'yoga',
-  // socket-registry / ultrathink
-  'acorn',
-  'npm',
-])
+// Stage / build-root / mode / sibling-package vocabularies are imported
+// from `.claude/hooks/path-guard/segments.mts` (the canonical source).
+// Both this gate and the path-guard hook share that single definition
+// — Mantra: 1 path, 1 reference.
 
 // File-path patterns that legitimately enumerate path segments.
 const EXEMPT_FILE_PATTERNS: RegExp[] = [

--- a/scripts/check-paths.mts
+++ b/scripts/check-paths.mts
@@ -67,6 +67,7 @@
  *   2 — gate itself crashed
  */
 
+import { createHash } from 'node:crypto'
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -179,6 +180,7 @@ const args = parseArgs({
     explain: { type: 'boolean', default: false },
     json: { type: 'boolean', default: false },
     quiet: { type: 'boolean', default: false },
+    'show-hashes': { type: 'boolean', default: false },
   },
   strict: false,
 })
@@ -195,6 +197,7 @@ type AllowlistEntry = {
   pattern?: string
   rule?: string
   line?: number
+  snippet_hash?: string
   reason: string
 }
 
@@ -315,6 +318,36 @@ const unquote = (s: string): string => {
 
 const ALLOWLIST = loadAllowlist()
 
+/**
+ * Stable, normalized snippet hash. Whitespace-insensitive so trivial
+ * reformatting (indent change, trailing comma, line wrap) doesn't
+ * invalidate an allowlist entry, but content-changing edits do. The
+ * hash exposes only the first 12 hex chars (~48 bits) which is plenty
+ * for collision-resistance within a single repo's finding set and
+ * keeps the YAML readable.
+ */
+const snippetHash = (snippet: string): string => {
+  const normalized = snippet.replace(/\s+/g, ' ').trim()
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 12)
+}
+
+/**
+ * Allowlist matching trades off two failure modes:
+ *
+ *   - Drift via reformatting (a line shift breaks an entry, the
+ *     finding re-surfaces, devs paper over with a new entry).
+ *   - Stealth allowlisting (an entry pinned to "anywhere in this file"
+ *     silently exempts unrelated future violations).
+ *
+ * Strategy: exact line match OR `snippet_hash` match (whitespace-
+ * normalized SHA-256, first 12 hex). Either is sufficient. Lines stay
+ * exact (was ±2; the slack let reformatting silently slide), and
+ * `snippet_hash` provides reformatting-tolerant matching that's still
+ * tied to the literal text — paste-and-edit cheating would change the
+ * hash. If neither `line` nor `snippet_hash` is provided, the entry
+ * matches purely by `rule` + `file` + `pattern` (file-level exempt;
+ * use sparingly and always pair with a precise `pattern`).
+ */
 const isAllowlisted = (finding: Finding): boolean =>
   ALLOWLIST.some(entry => {
     if (entry.rule && entry.rule !== finding.rule) {
@@ -326,8 +359,17 @@ const isAllowlisted = (finding: Finding): boolean =>
     if (entry.pattern && !finding.snippet.includes(entry.pattern)) {
       return false
     }
-    if (entry.line !== undefined && Math.abs(entry.line - finding.line) > 2) {
-      return false
+    const lineProvided = entry.line !== undefined
+    const hashProvided =
+      typeof entry.snippet_hash === 'string' && entry.snippet_hash.length > 0
+    if (lineProvided || hashProvided) {
+      const lineMatches =
+        lineProvided && entry.line === finding.line
+      const hashMatches =
+        hashProvided && entry.snippet_hash === snippetHash(finding.snippet)
+      if (!(lineMatches || hashMatches)) {
+        return false
+      }
     }
     return true
   })
@@ -381,6 +423,27 @@ const walk = function* (
 // argument containing 2+ levels of nested function calls).
 const PATH_CALL_RE = /\bpath\.(?:join|resolve)\s*\(/g
 const STRING_LITERAL_RE = /(['"])((?:\\.|(?!\1)[^\\])*)\1/g
+
+// Template literal scanner. Captures backtick-delimited strings
+// (including those with `${...}` placeholders) so Rule A also catches
+// path construction via template literals like
+// `${buildDir}/out/Final/${binary}` or `build/${mode}/out/Final`.
+const TEMPLATE_LITERAL_RE = /`((?:\\.|(?:\$\{(?:[^{}]|\{[^{}]*\})*\})|(?!`)[^\\])*)`/g
+
+/**
+ * Convert a template-literal body into a synthetic forward-slash path
+ * by replacing `${...}` placeholders with a sentinel and normalizing
+ * separators. Returns the sequence of path segments split on `/`. The
+ * sentinel doesn't match any STAGE/BUILD_ROOT/MODE token, so a
+ * placeholder-only segment (`${binaryName}`) won't match those sets.
+ */
+const templateLiteralSegments = (body: string): string[] => {
+  // Strip placeholders so they don't introduce noise in segments.
+  // Empty result for a placeholder is fine; downstream filters by set
+  // membership and skips empties.
+  const stripped = body.replace(/\$\{(?:[^{}]|\{[^{}]*\})*\}/g, '\x00')
+  return stripped.split('/').filter(seg => seg.length > 0 && seg !== '\x00')
+}
 
 /**
  * Extract every `path.join(...)` and `path.resolve(...)` call from the
@@ -528,6 +591,54 @@ const scanCodeFile = (relPath: string): void => {
           break
         }
       }
+    }
+  }
+
+  // Rule A (template literal variant). Backtick strings like
+  // `${buildDir}/out/Final/${binary}` or `build/${mode}/${arch}/out/Final`
+  // construct paths the same way `path.join(...)` does — flag the
+  // same shapes. Skip raw imports / template tag positions by
+  // filtering out leading `import.meta.url`-style / tag positions
+  // implicitly: TEMPLATE_LITERAL_RE matches any backtick string and
+  // we rely on segment composition to decide if it's a path.
+  TEMPLATE_LITERAL_RE.lastIndex = 0
+  let tmpl: RegExpExecArray | null
+  while ((tmpl = TEMPLATE_LITERAL_RE.exec(content)) !== null) {
+    const body = tmpl[1] ?? ''
+    if (!body.includes('/')) {
+      continue
+    }
+    const segments = templateLiteralSegments(body)
+    const stages = segments.filter(s => STAGE_SEGMENTS.has(s))
+    const buildRoots = segments.filter(s => BUILD_ROOT_SEGMENTS.has(s))
+    const modes = segments.filter(s => MODE_SEGMENTS.has(s))
+    // Template literal trigger is tighter than path.join() because
+    // backtick strings often appear in patch fixtures, error messages,
+    // and other multi-line content that incidentally contains stage
+    // tokens like `wasm`. Require the canonical build-output shape:
+    //   - 'build' + 'out' + stage (canonical multi-stage layout), OR
+    //   - 2+ stage segments AND 'out' (e.g. `wasm/out/Final`), OR
+    //   - 'build' + stage + literal mode (back-compat with path.join).
+    const hasBuildAndOut =
+      buildRoots.includes('build') && buildRoots.includes('out')
+    const hasOut = buildRoots.includes('out')
+    const hasBuild = buildRoots.includes('build')
+    const triggersA =
+      (hasBuildAndOut && stages.length >= 1) ||
+      (stages.length >= 2 && hasOut) ||
+      (hasBuild && stages.length >= 1 && modes.length >= 1)
+    if (triggersA) {
+      const line = offsetToLine(tmpl.index)
+      const snippet = (lines[line - 1] ?? '').trim()
+      findings.push({
+        rule: 'A',
+        file: relPath,
+        line,
+        snippet,
+        message:
+          'Multi-stage path constructed inline via template literal (outside paths.mts).',
+        fix: 'Construct in the owning paths.mts (or use getFinalBinaryPath / getDownloadedDir from build-infra/lib/paths). Import the computed value here.',
+      })
     }
   }
 }
@@ -853,6 +964,9 @@ const main = (): number => {
     logger.log(`  [${f.rule}] ${f.file}:${f.line}`)
     logger.log(`      ${f.snippet}`)
     logger.log(`      → ${f.message}`)
+    if (args.values['show-hashes']) {
+      logger.log(`      snippet_hash: ${snippetHash(f.snippet)}`)
+    }
     if (args.values.explain) {
       logger.log(`      Fix: ${f.fix}`)
     }
@@ -862,6 +976,9 @@ const main = (): number => {
     logger.log('Run with --explain to see fix suggestions per finding.')
     logger.log(
       'Add intentional exceptions to .github/paths-allowlist.yml with a `reason` field.',
+    )
+    logger.log(
+      'Run with --show-hashes to print the snippet_hash for each finding (drift-resistant allowlisting).',
     )
   }
   return 1


### PR DESCRIPTION
## Summary

Updates `path-guard` infra in socket-registry with detection improvements and centralized vocabulary from socket-repo-template@bb21ab5.

Mantra: **1 path, 1 reference.** Every build/test/runtime path is constructed exactly once; everywhere else references the constructed value.

## Detection improvements

- **Template-literal path detection**: hook + gate now flag template-string build paths like `` `${PKG}/build/${mode}/${arch}/out/Final/...` `` that were previously invisible to a `path.join`-only scanner.
- **Drift-resistant allowlist**: replaces ±2-line tolerance with exact-line OR `snippet_hash` match. `snippet_hash` is a 12-char SHA-256 prefix of the whitespace-normalized snippet, surviving reformatting but invalidated by any content-changing edit.
- **`--show-hashes` flag**: print the hash for each finding when authoring an allowlist entry.
- **Centralized vocabulary** (`.claude/hooks/path-guard/segments.mts`): stage / build-root / mode / sibling-package sets are now imported by both the hook and the gate from a single canonical file. The two can no longer drift on what counts as a build-output path.

## Companion propagations

| Repo | Commit |
|------|--------|
| socket-btm | 0960ee27 |
| socket-repo-template | bb21ab5 |
| socket-tui | 8a0ab67 |
| socket-sdxgen | f4fd9c6 |
| ultrathink | e77b1e849 |
| socket-packageurl-js | dcf5d12 |
| socket-cli | (PR #1280) |
| socket-sdk-js | (PR #621) |

## Test plan

- [x] gate runs clean (`node scripts/check-paths.mts` exits 0)
- [ ] CI passes
