### PR TITLE
feat(actions): bootstrap @socketsecurity/lib from npm registry before pnpm install

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -14,6 +14,63 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Bootstrap @socketsecurity/lib from npm registry
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        ACTION_DIR: ${{ github.action_path }}
+      run: |
+        # Bootstrap @socketsecurity/lib into node_modules/ BEFORE
+        # pnpm install runs. Several Socket repos have root scripts
+        # (setup.mts, postinstall hooks) that import @socketsecurity/lib
+        # at module-load time. On a fresh checkout, pnpm install
+        # itself runs scripts that import the package — but pnpm
+        # install hasn't completed yet, so the imports fail with
+        # ERR_MODULE_NOT_FOUND. Pre-seeding from the npm registry
+        # tarball solves the chicken-and-egg.
+        #
+        # Skipped silently when:
+        #   - the repo has its own scripts/bootstrap-from-registry.mts
+        #     (the preinstall hook handles it; no need to duplicate)
+        #   - @socketsecurity/lib is already resolvable
+        #   - the repo doesn't depend on @socketsecurity/lib at all
+        #
+        # Before downloading, the version is checked against the Socket
+        # Firewall API (firewall-api.socket.dev/purl). Critical/high
+        # severity alerts block the bootstrap; firewall errors are
+        # non-fatal.
+        if [ -f scripts/bootstrap-from-registry.mts ]; then
+          echo "Repo has its own bootstrap-from-registry.mts; skipping action-level bootstrap."
+          exit 0
+        fi
+        if node -e "require.resolve('@socketsecurity/lib/package.json')" 2>/dev/null; then
+          echo "@socketsecurity/lib already resolvable; skipping bootstrap."
+          exit 0
+        fi
+        VERSION="$(node "$ACTION_DIR/read-pinned-version.mts" '@socketsecurity/lib')"
+        if [ -z "$VERSION" ]; then
+          echo "@socketsecurity/lib not pinned in this repo; skipping bootstrap."
+          exit 0
+        fi
+        # Firewall check — bail loudly on critical/high alerts.
+        if ! node "$ACTION_DIR/check-firewall.mts" '@socketsecurity/lib' "$VERSION"; then
+          exit 1
+        fi
+        echo "Bootstrapping @socketsecurity/lib@${VERSION} from npm registry..."
+        TARBALL_URL="https://registry.npmjs.org/@socketsecurity/lib/-/lib-${VERSION}.tgz"
+        TARBALL="$(mktemp -t socket-lib-XXXXXX.tgz)"
+        if ! curl -fsSL "$TARBALL_URL" -o "$TARBALL"; then
+          echo "Warning: failed to fetch ${TARBALL_URL}; pnpm install will resolve it." >&2
+          rm -f "$TARBALL"
+          exit 0
+        fi
+        DEST="node_modules/@socketsecurity/lib"
+        rm -rf "$DEST"
+        mkdir -p "$DEST"
+        tar -xzf "$TARBALL" --strip-components=1 -C "$DEST"
+        rm -f "$TARBALL"
+        echo "✓ @socketsecurity/lib@${VERSION} → ${DEST}"
+
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/install/check-firewall.mts
+++ b/.github/actions/install/check-firewall.mts
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Check a Socket package against the firewall API
+ * before downloading its tarball directly from the npm registry.
+ *
+ * Endpoint: GET https://firewall-api.socket.dev/purl/<encoded-purl>
+ * Response: { alerts?: [{ severity?, type?, key? }, ...] }
+ *
+ * Exits 0 if the package is OK to install (no critical/high alerts,
+ * or the firewall is unreachable — non-fatal so a network blip
+ * doesn't break the bootstrap).
+ *
+ * Exits 1 if the firewall reports a blocking alert
+ * (severity: critical | high).
+ *
+ * Usage:
+ *   node check-firewall.mts <package-name> <version>
+ */
+
+import { argv, exit, stderr, stdout } from 'node:process'
+
+const pkgName = argv[2]
+const version = argv[3]
+if (!pkgName || !version) {
+  stderr.write(
+    'Usage: node check-firewall.mts <package-name> <version>\n',
+  )
+  exit(2)
+}
+
+const FIREWALL_API_URL = 'https://firewall-api.socket.dev/purl'
+const FIREWALL_TIMEOUT_MS = 10_000
+const BLOCK_SEVERITIES = new Set(['critical', 'high'])
+
+const purl = `pkg:npm/${pkgName}@${version}`
+const url = `${FIREWALL_API_URL}/${encodeURIComponent(purl)}`
+
+interface Alert {
+  severity?: string
+  type?: string
+  key?: string
+}
+interface FirewallResponse {
+  alerts?: Alert[]
+}
+
+const main = async (): Promise<number> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FIREWALL_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': 'socket-registry-install-action/1.0',
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    })
+    clearTimeout(timer)
+    if (!res.ok) {
+      stderr.write(
+        `firewall-api: HTTP ${res.status} for ${purl} — proceeding anyway (non-fatal)\n`,
+      )
+      return 0
+    }
+    const data = (await res.json()) as FirewallResponse
+    const blocking = (data.alerts ?? []).filter(
+      a => typeof a.severity === 'string' && BLOCK_SEVERITIES.has(a.severity),
+    )
+    if (blocking.length > 0) {
+      stderr.write(
+        `\n✗ Socket Firewall BLOCKED ${pkgName}@${version} (${blocking.length} alert(s)):\n`,
+      )
+      for (const a of blocking.slice(0, 10)) {
+        stderr.write(
+          `    ${a.severity}: ${a.type ?? a.key ?? 'unknown'}\n`,
+        )
+      }
+      stderr.write(
+        '\nFix: bump the pinned version in pnpm-workspace.yaml or package.json.\n',
+      )
+      return 1
+    }
+    stdout.write(`✓ ${pkgName}@${version} cleared by Socket Firewall\n`)
+    return 0
+  } catch (e) {
+    clearTimeout(timer)
+    // Firewall errors are non-fatal — allow bootstrap to proceed.
+    // Network blips or registry-down shouldn't break a fresh clone.
+    stderr.write(
+      `firewall-api: ${e instanceof Error ? e.message : String(e)} — proceeding anyway (non-fatal)\n`,
+    )
+    return 0
+  }
+}
+
+main().then(code => exit(code))

--- a/.github/actions/install/read-pinned-version.mts
+++ b/.github/actions/install/read-pinned-version.mts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Print the pinned version of a Socket package to
+ * stdout, reading from (in order):
+ *   1. pnpm-workspace.yaml `catalog:` entries
+ *   2. Root package.json `dependencies` / `devDependencies`
+ *      (skipping "catalog:" / "workspace:" / "*" / "" placeholders)
+ *
+ * Prints the empty string if not pinned (caller decides what to do).
+ *
+ * Usage:
+ *   node read-pinned-version.mts <package-name>
+ *
+ * Used by the install composite action's bootstrap step. Kept as a
+ * standalone .mts file (rather than an inline `node -e "..."` blob
+ * in action.yml) so the YAML stays readable and the parsing logic
+ * is testable.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+
+import { argv, exit, stdout } from 'node:process'
+
+const pkgName = argv[2]
+if (!pkgName) {
+  process.stderr.write('Usage: node read-pinned-version.mts <package-name>\n')
+  exit(2)
+}
+
+const stripRange = (v: string): string => v.replace(/^[\^~>=<]+/, '').trim()
+
+const fromCatalog = (pkg: string): string | null => {
+  if (!existsSync('pnpm-workspace.yaml')) {
+    return null
+  }
+  const content = readFileSync('pnpm-workspace.yaml', 'utf8')
+  const lines = content.split('\n')
+  let inCatalog = false
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '')
+    if (/^catalog:\s*$/.test(line)) {
+      inCatalog = true
+      continue
+    }
+    if (!inCatalog) {
+      continue
+    }
+    // Leave the catalog block on the next top-level key (no leading
+    // whitespace, ends with ':').
+    if (/^\S.*:\s*$/.test(line)) {
+      inCatalog = false
+      continue
+    }
+    const m = line.match(
+      /^\s+['"]?([@A-Za-z0-9_/-]+)['"]?\s*:\s*['"]?([^'"\s]+)['"]?\s*$/,
+    )
+    if (m && m[1] === pkg) {
+      return stripRange(m[2]!)
+    }
+  }
+  return null
+}
+
+const fromPackageJson = (pkg: string): string | null => {
+  if (!existsSync('package.json')) {
+    return null
+  }
+  const json = JSON.parse(readFileSync('package.json', 'utf8'))
+  for (const field of ['dependencies', 'devDependencies'] as const) {
+    const deps = json[field]
+    if (deps && typeof deps[pkg] === 'string') {
+      const v: string = deps[pkg]
+      if (
+        v !== '' &&
+        v !== '*' &&
+        !v.startsWith('catalog:') &&
+        !v.startsWith('workspace:')
+      ) {
+        return stripRange(v)
+      }
+    }
+  }
+  return null
+}
+
+const version = fromCatalog(pkgName) ?? fromPackageJson(pkgName)
+if (version) {
+  stdout.write(version)
+}


### PR DESCRIPTION
## Summary

Adds a bootstrap step to `.github/actions/install/action.yml` that pre-seeds `@socketsecurity/lib` into `node_modules/` from the npm registry tarball **before** `pnpm install` runs. Verifies the version against `firewall-api.socket.dev` first.

## Why

Several Socket repos have root scripts (`setup.mts`, postinstall hooks, `xport-emit-schema`, etc.) that import `@socketsecurity/lib` at module-load time. On a fresh checkout, `pnpm install` itself runs scripts that import the package — but `pnpm install` hasn't completed yet, so the imports fail with `ERR_MODULE_NOT_FOUND`. Pre-seeding from the registry tarball solves the chicken-and-egg.

## Behavior

- **Skips silently** if the repo has its own `scripts/bootstrap-from-registry.mts` (preinstall hook handles it; no duplication).
- **Skips** if `@socketsecurity/lib` is already resolvable.
- **Reads the pinned version** from `pnpm-workspace.yaml` `catalog:` OR root `package.json` `dependencies`/`devDependencies` — single source of truth, no hardcoded version.
- **Skips** if not pinned (repo doesn't depend on it).
- **Firewall check** before download — `GET https://firewall-api.socket.dev/purl/<encoded-purl>`. Critical/high severity alerts hard-block the bootstrap. Firewall errors are non-fatal so a network blip can't brick fresh clones.
- Uses `curl` + `tar` (POSIX, no extra tooling).

## Files

| File | Purpose |
|------|---------|
| `.github/actions/install/action.yml` | Adds the bootstrap step before `pnpm install` |
| `.github/actions/install/read-pinned-version.mts` | Parses `pnpm-workspace.yaml` catalog + `package.json` deps to find the pinned version. Standalone .mts so action.yml stays readable. |
| `.github/actions/install/check-firewall.mts` | Queries `firewall-api.socket.dev/purl`, blocks on critical/high alerts, non-fatal on errors. |

## Companion PRs

- socket-cli #1279 — carries `scripts/bootstrap-from-registry.mts` wired via `preinstall`
- socket-sdk-js #620 — same

This action handles bootstrapping for the rest of the fleet (where adding a per-repo script would be heavier than warranted).

## Test plan

- [x] YAML parses
- [x] `read-pinned-version.mts @socketsecurity/lib` returns the pinned version
- [x] `check-firewall.mts @socketsecurity/lib 5.24.0` exits 0 (clean)
- [ ] CI: composite action runs bootstrap step on a fresh checkout without errors
- [ ] CI: the verify step (existing) confirms `@socketsecurity/lib` is resolvable after install
