### PR TITLE
chore(claude): add private-name rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ See `docs/references/error-messages.md` for worked examples and anti-patterns.
 - Forbidden to create docs unless requested
 - 🚨 **NEVER use `npx`, `pnpm dlx`, or `yarn dlx`** — use `pnpm exec <pkg>` or `pnpm run <script>`; add tools as pinned devDependencies first # zizmor: documentation-prohibition
 - **minimumReleaseAge**: NEVER add packages to `minimumReleaseAgeExclude` in CI. Locally, ASK before adding — the age threshold is a security control.
+- 🚨 **NEVER mention private repos or internal project names** in commits, PR titles/descriptions/comments, issues, release notes, or any public-surface text. Internal codenames, unreleased product names, internal tooling repo names not on the public org page, customer names, partner names — none belong in public surfaces. **Omit the reference entirely.** Don't substitute a placeholder ("an internal tool", "a downstream consumer", etc.) — the placeholder itself is a tell that something is being elided. Rewrite the sentence to not need the reference at all.
 
 ## EVOLUTION
 


### PR DESCRIPTION
## Summary

Mirror of the rule landed in socket-lib + socket-repo-template. Omit
private repo and internal project names from public-surface text
(commits, PR titles/descriptions/comments, issues, release notes);
don't substitute a placeholder — the placeholder itself is a tell.

## Test plan

- [ ] CI green