### PR TITLE
chore(actions): cascade install pin to 76975c37 (Layer 2b)

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -68,6 +68,6 @@ runs:
         working-directory: ${{ inputs.working-directory }}
 
     - name: Install dependencies
-      uses: SocketDev/socket-registry/.github/actions/install@c5c61c327186d6c3e3a3b4c7e5ee49eef4ec15df # main
+      uses: SocketDev/socket-registry/.github/actions/install@76975c37407b88e1af0b75292c3ce6490ce17813 # main
       with:
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Layer 2b cascade after PR #279 added the bootstrap-from-registry step to install/action.yml.

Bumps `SocketDev/socket-registry/.github/actions/install` from c5c61c32 to 76975c37.

Layer 2a (setup) doesn't reference install, so the cascade starts here. Next: Layer 3 (ci.yml, provenance.yml, weekly-update.yml) will bump setup-and-install once this merges.