### PR TITLE
chore(actions): cascade setup-and-install pin to b533a39f (Layer 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.check-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ inputs.check-node-version }}
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.lint-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ inputs.lint-node-version }}
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.type-check-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ inputs.type-check-node-version }}
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ inputs.test-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -113,7 +113,7 @@ jobs:
             exit 1
           fi
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           checkout-ref: ${{ inputs.ref }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -126,7 +126,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           socket-api-key: ${{ secrets.SOCKET_API_TOKEN }}
 
@@ -176,7 +176,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@acc3a11ebeeed9b9697f6f9ddb51ac190220beab # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b533a39fa35055c5a3aa7091fb008153a8e8a789 # main
         with:
           checkout-fetch-depth: ${{ inputs.checkout-fetch-depth }}
           socket-api-key: ${{ secrets.SOCKET_API_TOKEN }}


### PR DESCRIPTION
Layer 3 cascade. Bumps setup-and-install from acc3a11e to b533a39f in ci.yml, provenance.yml, weekly-update.yml.

The merge SHA of this PR is the **propagation SHA** for external consumer repos.

Chain: install (Layer 1, #279) → setup-and-install (Layer 2b, #281) → reusable workflows (this PR, Layer 3) → _local-not-for-reuse-* (Layer 4).