### PR TITLE
chore(publish): add publishConfig {access:public, provenance:true} across 131 npm packages

### DIFF
--- a/packages/npm/abab/package.json
+++ b/packages/npm/abab/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/aggregate-error/package.json
+++ b/packages/npm/aggregate-error/package.json
@@ -54,5 +54,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array-buffer-byte-length/package.json
+++ b/packages/npm/array-buffer-byte-length/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array-flatten/package.json
+++ b/packages/npm/array-flatten/package.json
@@ -33,5 +33,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array-includes/package.json
+++ b/packages/npm/array-includes/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.from/package.json
+++ b/packages/npm/array.from/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.of/package.json
+++ b/packages/npm/array.of/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.at/package.json
+++ b/packages/npm/array.prototype.at/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.every/package.json
+++ b/packages/npm/array.prototype.every/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.filter/package.json
+++ b/packages/npm/array.prototype.filter/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.find/package.json
+++ b/packages/npm/array.prototype.find/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.findlast/package.json
+++ b/packages/npm/array.prototype.findlast/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.findlastindex/package.json
+++ b/packages/npm/array.prototype.findlastindex/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.flat/package.json
+++ b/packages/npm/array.prototype.flat/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.flatmap/package.json
+++ b/packages/npm/array.prototype.flatmap/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.foreach/package.json
+++ b/packages/npm/array.prototype.foreach/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.map/package.json
+++ b/packages/npm/array.prototype.map/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.reduce/package.json
+++ b/packages/npm/array.prototype.reduce/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.toreversed/package.json
+++ b/packages/npm/array.prototype.toreversed/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/array.prototype.tosorted/package.json
+++ b/packages/npm/array.prototype.tosorted/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/arraybuffer.prototype.slice/package.json
+++ b/packages/npm/arraybuffer.prototype.slice/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/assert/package.json
+++ b/packages/npm/assert/package.json
@@ -39,5 +39,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/asynciterator.prototype/package.json
+++ b/packages/npm/asynciterator.prototype/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/available-typed-arrays/package.json
+++ b/packages/npm/available-typed-arrays/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/date/package.json
+++ b/packages/npm/date/package.json
@@ -318,5 +318,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/deep-equal/package.json
+++ b/packages/npm/deep-equal/package.json
@@ -65,5 +65,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/define-properties/package.json
+++ b/packages/npm/define-properties/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es-aggregate-error/package.json
+++ b/packages/npm/es-aggregate-error/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es-define-property/package.json
+++ b/packages/npm/es-define-property/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es-get-iterator/package.json
+++ b/packages/npm/es-get-iterator/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es-iterator-helpers/package.json
+++ b/packages/npm/es-iterator-helpers/package.json
@@ -398,5 +398,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es-set-tostringtag/package.json
+++ b/packages/npm/es-set-tostringtag/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es6-object-assign/package.json
+++ b/packages/npm/es6-object-assign/package.json
@@ -36,5 +36,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/es6-symbol/package.json
+++ b/packages/npm/es6-symbol/package.json
@@ -40,5 +40,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/for-each/package.json
+++ b/packages/npm/for-each/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/function-bind/package.json
+++ b/packages/npm/function-bind/package.json
@@ -36,5 +36,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/function.prototype.name/package.json
+++ b/packages/npm/function.prototype.name/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/functions-have-names/package.json
+++ b/packages/npm/functions-have-names/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/get-symbol-description/package.json
+++ b/packages/npm/get-symbol-description/package.json
@@ -36,5 +36,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/globalthis/package.json
+++ b/packages/npm/globalthis/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/gopd/package.json
+++ b/packages/npm/gopd/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/harmony-reflect/package.json
+++ b/packages/npm/harmony-reflect/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/has-property-descriptors/package.json
+++ b/packages/npm/has-property-descriptors/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/has-proto/package.json
+++ b/packages/npm/has-proto/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/has-symbols/package.json
+++ b/packages/npm/has-symbols/package.json
@@ -36,5 +36,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/has-tostringtag/package.json
+++ b/packages/npm/has-tostringtag/package.json
@@ -36,5 +36,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/has/package.json
+++ b/packages/npm/has/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/hasown/package.json
+++ b/packages/npm/hasown/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/hyrious__bun.lockb/package.json
+++ b/packages/npm/hyrious__bun.lockb/package.json
@@ -59,5 +59,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/indent-string/package.json
+++ b/packages/npm/indent-string/package.json
@@ -54,5 +54,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/internal-slot/package.json
+++ b/packages/npm/internal-slot/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-arguments/package.json
+++ b/packages/npm/is-arguments/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-array-buffer/package.json
+++ b/packages/npm/is-array-buffer/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-bigint/package.json
+++ b/packages/npm/is-bigint/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-boolean-object/package.json
+++ b/packages/npm/is-boolean-object/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-core-module/package.json
+++ b/packages/npm/is-core-module/package.json
@@ -46,5 +46,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-date-object/package.json
+++ b/packages/npm/is-date-object/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-generator-function/package.json
+++ b/packages/npm/is-generator-function/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-interactive/package.json
+++ b/packages/npm/is-interactive/package.json
@@ -54,5 +54,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-map/package.json
+++ b/packages/npm/is-map/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-nan/package.json
+++ b/packages/npm/is-nan/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-negative-zero/package.json
+++ b/packages/npm/is-negative-zero/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-number-object/package.json
+++ b/packages/npm/is-number-object/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-regex/package.json
+++ b/packages/npm/is-regex/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-set/package.json
+++ b/packages/npm/is-set/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-shared-array-buffer/package.json
+++ b/packages/npm/is-shared-array-buffer/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-string/package.json
+++ b/packages/npm/is-string/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-symbol/package.json
+++ b/packages/npm/is-symbol/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-typed-array/package.json
+++ b/packages/npm/is-typed-array/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-unicode-supported/package.json
+++ b/packages/npm/is-unicode-supported/package.json
@@ -54,5 +54,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-weakmap/package.json
+++ b/packages/npm/is-weakmap/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-weakref/package.json
+++ b/packages/npm/is-weakref/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/is-weakset/package.json
+++ b/packages/npm/is-weakset/package.json
@@ -44,5 +44,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/isarray/package.json
+++ b/packages/npm/isarray/package.json
@@ -45,5 +45,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/iterator.prototype/package.json
+++ b/packages/npm/iterator.prototype/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/json-stable-stringify/package.json
+++ b/packages/npm/json-stable-stringify/package.json
@@ -33,5 +33,9 @@
       "cleanup",
       "levelup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/jsonify/package.json
+++ b/packages/npm/jsonify/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/number-is-nan/package.json
+++ b/packages/npm/number-is-nan/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object-assign/package.json
+++ b/packages/npm/object-assign/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object-is/package.json
+++ b/packages/npm/object-is/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object-keys/package.json
+++ b/packages/npm/object-keys/package.json
@@ -40,5 +40,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.assign/package.json
+++ b/packages/npm/object.assign/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.entries/package.json
+++ b/packages/npm/object.entries/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.fromentries/package.json
+++ b/packages/npm/object.fromentries/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.getownpropertydescriptors/package.json
+++ b/packages/npm/object.getownpropertydescriptors/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.getprototypeof/package.json
+++ b/packages/npm/object.getprototypeof/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.groupby/package.json
+++ b/packages/npm/object.groupby/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.hasown/package.json
+++ b/packages/npm/object.hasown/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/object.values/package.json
+++ b/packages/npm/object.values/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/path-parse/package.json
+++ b/packages/npm/path-parse/package.json
@@ -34,5 +34,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/promise.allsettled/package.json
+++ b/packages/npm/promise.allsettled/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/promise.any/package.json
+++ b/packages/npm/promise.any/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/querystringify/package.json
+++ b/packages/npm/querystringify/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/reflect.getprototypeof/package.json
+++ b/packages/npm/reflect.getprototypeof/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/reflect.ownkeys/package.json
+++ b/packages/npm/reflect.ownkeys/package.json
@@ -49,5 +49,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/regexp.prototype.flags/package.json
+++ b/packages/npm/regexp.prototype.flags/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/safe-array-concat/package.json
+++ b/packages/npm/safe-array-concat/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/safe-buffer/package.json
+++ b/packages/npm/safe-buffer/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/safe-regex-test/package.json
+++ b/packages/npm/safe-regex-test/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/safer-buffer/package.json
+++ b/packages/npm/safer-buffer/package.json
@@ -40,5 +40,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/set-function-length/package.json
+++ b/packages/npm/set-function-length/package.json
@@ -36,5 +36,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/side-channel/package.json
+++ b/packages/npm/side-channel/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.fromcodepoint/package.json
+++ b/packages/npm/string.fromcodepoint/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.at/package.json
+++ b/packages/npm/string.prototype.at/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.codepointat/package.json
+++ b/packages/npm/string.prototype.codepointat/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.endswith/package.json
+++ b/packages/npm/string.prototype.endswith/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.includes/package.json
+++ b/packages/npm/string.prototype.includes/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.matchall/package.json
+++ b/packages/npm/string.prototype.matchall/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.padend/package.json
+++ b/packages/npm/string.prototype.padend/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.padstart/package.json
+++ b/packages/npm/string.prototype.padstart/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.repeat/package.json
+++ b/packages/npm/string.prototype.repeat/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.replaceall/package.json
+++ b/packages/npm/string.prototype.replaceall/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.split/package.json
+++ b/packages/npm/string.prototype.split/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.startswith/package.json
+++ b/packages/npm/string.prototype.startswith/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.trim/package.json
+++ b/packages/npm/string.prototype.trim/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.trimend/package.json
+++ b/packages/npm/string.prototype.trimend/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.trimleft/package.json
+++ b/packages/npm/string.prototype.trimleft/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.trimright/package.json
+++ b/packages/npm/string.prototype.trimright/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/string.prototype.trimstart/package.json
+++ b/packages/npm/string.prototype.trimstart/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/typed-array-buffer/package.json
+++ b/packages/npm/typed-array-buffer/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/typed-array-byte-length/package.json
+++ b/packages/npm/typed-array-byte-length/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/typed-array-byte-offset/package.json
+++ b/packages/npm/typed-array-byte-offset/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/typed-array-length/package.json
+++ b/packages/npm/typed-array-length/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/typedarray.prototype.slice/package.json
+++ b/packages/npm/typedarray.prototype.slice/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/typedarray/package.json
+++ b/packages/npm/typedarray/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/unbox-primitive/package.json
+++ b/packages/npm/unbox-primitive/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/util.promisify/package.json
+++ b/packages/npm/util.promisify/package.json
@@ -48,5 +48,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/which-boxed-primitive/package.json
+++ b/packages/npm/which-boxed-primitive/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/which-collection/package.json
+++ b/packages/npm/which-collection/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/which-typed-array/package.json
+++ b/packages/npm/which-typed-array/package.json
@@ -32,5 +32,9 @@
     "categories": [
       "cleanup"
     ]
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/npm/yocto-spinner/package.json
+++ b/packages/npm/yocto-spinner/package.json
@@ -57,5 +57,9 @@
   },
   "dependencies": {
     "yoctocolors-cjs": "2.1.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Summary
- Bulk-add `publishConfig: {access: "public", provenance: true}` to every `package.json` under `packages/npm/*`.
- Pins access + provenance attestation to each package manifest so the policy survives any direct-publish path that bypasses the workflow's `--provenance` CLI flag.
- 131 packages updated; no other key-ordering changes.

## Test plan
- [ ] Next workflow-driven publish includes provenance attestation on every published package
- [ ] CI green