### PR TITLE
chore: rename socket-repo-template to socket-wheelhouse

### DIFF
--- a/.claude/hooks/auth-rotation-reminder/README.md
+++ b/.claude/hooks/auth-rotation-reminder/README.md
@@ -142,6 +142,6 @@ Other hooks can adopt the same `.snooze` pattern. The convention:
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/auth-rotation-reminder)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/auth-rotation-reminder)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/check-new-deps/README.md
+++ b/.claude/hooks/check-new-deps/README.md
@@ -129,6 +129,6 @@ All dependencies use `catalog:` references from the workspace root
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/check-new-deps)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/check-new-deps)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/cross-repo-guard/README.md
+++ b/.claude/hooks/cross-repo-guard/README.md
@@ -62,7 +62,7 @@ socket-cli
 socket-lib
 socket-packageurl-js
 socket-registry
-socket-repo-template
+socket-wheelhouse
 socket-sdk-js
 socket-sdxgen
 socket-stuie
@@ -98,6 +98,6 @@ companion git-side scanner in `.git-hooks/_helpers.mts` (`FLEET_REPO_NAMES`)
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/cross-repo-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/cross-repo-guard)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/cross-repo-guard/index.mts
+++ b/.claude/hooks/cross-repo-guard/index.mts
@@ -53,7 +53,7 @@ const FLEET_REPO_NAMES = [
   'socket-lib',
   'socket-packageurl-js',
   'socket-registry',
-  'socket-repo-template',
+  'socket-wheelhouse',
   'socket-sdk-js',
   'socket-sdxgen',
   'socket-stuie',

--- a/.claude/hooks/gitmodules-comment-guard/README.md
+++ b/.claude/hooks/gitmodules-comment-guard/README.md
@@ -74,6 +74,6 @@ In `.claude/settings.json`:
 ## Cross-fleet sync
 
 This hook lives in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/gitmodules-comment-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/gitmodules-comment-guard)
 and is required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/logger-guard/README.md
+++ b/.claude/hooks/logger-guard/README.md
@@ -99,6 +99,6 @@ node --test test/*.test.mts
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/logger-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/logger-guard)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/no-fleet-fork-guard/README.md
+++ b/.claude/hooks/no-fleet-fork-guard/README.md
@@ -6,7 +6,7 @@ PreToolUse Edit/Write hook that blocks edits to fleet-canonical files inside dow
 
 The fleet rule "Never fork fleet-canonical files locally" (CLAUDE.md fleet block, full reference at [`docs/claude.md/no-local-fork-canonical.md`](../../../docs/claude.md/no-local-fork-canonical.md)).
 
-Fleet-canonical surfaces (anything tracked by `socket-repo-template/scripts/sync-scaffolding/manifest.mts`):
+Fleet-canonical surfaces (anything tracked by `socket-wheelhouse/scripts/sync-scaffolding/manifest.mts`):
 
 - `.config/oxlint-plugin/` — oxlint plugin index + rules
 - `.git-hooks/` — commit-msg / pre-commit / pre-push hooks + helpers
@@ -15,14 +15,14 @@ Fleet-canonical surfaces (anything tracked by `socket-repo-template/scripts/sync
 - `docs/claude.md/` — CLAUDE.md offshoot references
 - `.husky/` — Husky entry shims
 
-When Claude tries to Edit/Write a file under one of these prefixes in a fleet member (any repo with `CLAUDE.md` containing the `BEGIN FLEET-CANONICAL` marker, except `socket-repo-template/template/`), the hook exits 2 with a stderr message that:
+When Claude tries to Edit/Write a file under one of these prefixes in a fleet member (any repo with `CLAUDE.md` containing the `BEGIN FLEET-CANONICAL` marker, except `socket-wheelhouse/template/`), the hook exits 2 with a stderr message that:
 
 1. States the rule.
-2. Names the canonical file path inside `socket-repo-template/template/...`.
+2. Names the canonical file path inside `socket-wheelhouse/template/...`.
 3. Provides the exact `sync-scaffolding` command to cascade.
 4. Documents the bypass phrase.
 
-Edits inside `socket-repo-template/template/` are ALLOWED — that IS the canonical home.
+Edits inside `socket-wheelhouse/template/` are ALLOWED — that IS the canonical home.
 
 ## Bypass
 
@@ -41,7 +41,7 @@ The hook catches the failure mode where Claude reaches for a "quick fix" in a do
 For each Edit/Write/MultiEdit call:
 
 1. Resolve `tool_input.file_path` to an absolute path.
-2. Check if the path contains `/socket-repo-template/template/` — if yes, allow.
+2. Check if the path contains `/socket-wheelhouse/template/` — if yes, allow.
 3. Walk up directories looking for a fleet repo root: `package.json` AND `CLAUDE.md` containing the `BEGIN FLEET-CANONICAL` marker.
 4. If no fleet repo root is found (the file is outside any fleet repo), allow.
 5. Compute the file path relative to the repo root.

--- a/.claude/hooks/no-fleet-fork-guard/index.mts
+++ b/.claude/hooks/no-fleet-fork-guard/index.mts
@@ -4,14 +4,14 @@
 // Blocks Edit/Write tool calls that target a fleet-canonical file
 // path inside a downstream fleet repo. The fleet rule
 // ("Never fork fleet-canonical files locally") says these files
-// MUST be edited in socket-repo-template/template/... and cascaded
+// MUST be edited in socket-wheelhouse/template/... and cascaded
 // out via sync-scaffolding — never branched locally in a downstream
 // repo. Local forks turn into "drift to preserve" hacks that block
 // fleet-wide improvements from reaching the forked repo.
 //
 // The hook detects a fleet-canonical edit by:
 //   1. Resolving the absolute file path of the Edit/Write target.
-//   2. Checking if the path is INSIDE socket-repo-template/template/
+//   2. Checking if the path is INSIDE socket-wheelhouse/template/
 //      → allow (this IS the canonical home).
 //   3. Otherwise, checking if the path matches a fleet-canonical
 //      surface prefix:
@@ -86,16 +86,16 @@ const BYPASS_PHRASE = 'Allow fleet-fork bypass'
 // the no-revert-guard hook's window.
 const BYPASS_LOOKBACK_USER_TURNS = 8
 
-// File-path tokens that identify the socket-repo-template canonical
+// File-path tokens that identify the socket-wheelhouse canonical
 // home. If the resolved absolute path contains one of these, we're
 // editing the source of truth — allow.
 //
-// `socket-repo-template/template/` covers the standard checkout shape
-// (e.g. /Users/<user>/projects/socket-repo-template/template/...).
+// `socket-wheelhouse/template/` covers the standard checkout shape
+// (e.g. /Users/<user>/projects/socket-wheelhouse/template/...).
 // `repo-template/template/` covers any rename / mirror / fork that
 // keeps the trailing component.
 const TEMPLATE_PATH_TOKENS = [
-  '/socket-repo-template/template/',
+  '/socket-wheelhouse/template/',
   '/repo-template/template/',
 ]
 
@@ -267,12 +267,12 @@ async function main(): Promise<number> {
       `Repo:  ${path.basename(repoRoot)}`,
       ``,
       `Fleet-canonical files (anything tracked by`,
-      `socket-repo-template/scripts/sync-scaffolding/manifest.mts) MUST`,
-      `be edited in socket-repo-template/template/${relToRepo} and`,
+      `socket-wheelhouse/scripts/sync-scaffolding/manifest.mts) MUST`,
+      `be edited in socket-wheelhouse/template/${relToRepo} and`,
       `cascaded out — never branched locally in a downstream fleet repo.`,
       ``,
       `Fix path:`,
-      `  1. Edit socket-repo-template/template/${relToRepo}`,
+      `  1. Edit socket-wheelhouse/template/${relToRepo}`,
       `  2. Commit + push template`,
       `  3. Cascade with: node scripts/sync-scaffolding/main.mts \\`,
       `       --target ${repoRoot} --fix`,

--- a/.claude/hooks/no-fleet-fork-guard/test/index.test.mts
+++ b/.claude/hooks/no-fleet-fork-guard/test/index.test.mts
@@ -275,15 +275,15 @@ test('bypass phrase variants do NOT count', async () => {
   }
 })
 
-test('paths under socket-repo-template/template/ always pass', async () => {
+test('paths under socket-wheelhouse/template/ always pass', async () => {
   // Even if Claude tries to spell out a path that would otherwise
-  // match a canonical prefix, anything under .../socket-repo-template/
+  // match a canonical prefix, anything under .../socket-wheelhouse/
   // template/ is allowed since that IS the canonical home.
   const repo = mkdtempSync(path.join(tmpdir(), 'fake-srt-'))
   try {
     const file = path.join(
       repo,
-      'socket-repo-template/template/.git-hooks/_helpers.mts',
+      'socket-wheelhouse/template/.git-hooks/_helpers.mts',
     )
     mkdirSync(path.dirname(file), { recursive: true })
     writeFileSync(file, '// canonical home\n')

--- a/.claude/hooks/path-guard/README.md
+++ b/.claude/hooks/path-guard/README.md
@@ -103,7 +103,7 @@ negative test in `test/path-guard.test.mts`.
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/path-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/path-guard)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.
 

--- a/.claude/hooks/path-guard/segments.mts
+++ b/.claude/hooks/path-guard/segments.mts
@@ -6,7 +6,7 @@
 // consumers import from here so they can never drift apart.
 //
 // Synced byte-identically across the Socket fleet via
-// socket-repo-template/scripts/sync-scaffolding.mts (IDENTICAL_FILES).
+// socket-wheelhouse/scripts/sync-scaffolding.mts (IDENTICAL_FILES).
 // When adding a new stage/build-root/mode/sibling, edit this file in
 // the template and re-sync.
 
@@ -42,7 +42,7 @@ export const MODE_SEGMENTS = new Set(['dev', 'prod', 'shared'])
 // listing every fleet package keeps Rule B firing in any repo. When a
 // new package joins the workspace, add it here and propagate via
 // `node scripts/sync-scaffolding.mts --all --fix` from
-// socket-repo-template.
+// socket-wheelhouse.
 export const KNOWN_SIBLING_PACKAGES = new Set([
   // socket-btm
   'bin-infra',

--- a/.claude/hooks/private-name-guard/README.md
+++ b/.claude/hooks/private-name-guard/README.md
@@ -72,6 +72,6 @@ Always `0`. The hook never blocks; it only prints to stderr.
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/private-name-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/private-name-guard)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/public-surface-reminder/README.md
+++ b/.claude/hooks/public-surface-reminder/README.md
@@ -81,6 +81,6 @@ Always `0`. The hook prints a reminder and steps aside.
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/public-surface-reminder)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/public-surface-reminder)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/release-workflow-guard/README.md
+++ b/.claude/hooks/release-workflow-guard/README.md
@@ -102,6 +102,6 @@ a wrong fire is irreversible; prime when it's recoverable.
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/release-workflow-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/release-workflow-guard)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/setup-security-tools/README.md
+++ b/.claude/hooks/setup-security-tools/README.md
@@ -142,6 +142,6 @@ the shim under `~/.socket/sfw/shims/`, not the real binary.
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/setup-security-tools)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/setup-security-tools)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/stale-process-sweeper/README.md
+++ b/.claude/hooks/stale-process-sweeper/README.md
@@ -89,6 +89,6 @@ node --test test/*.test.mts
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/stale-process-sweeper)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/stale-process-sweeper)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.

--- a/.claude/hooks/token-guard/README.md
+++ b/.claude/hooks/token-guard/README.md
@@ -79,7 +79,7 @@ negative test in `test/token-guard.test.mts`.
 ## Cross-fleet sync
 
 This README and the hook itself live in
-[`socket-repo-template`](https://github.com/SocketDev/socket-repo-template/tree/main/template/.claude/hooks/token-guard)
+[`socket-wheelhouse`](https://github.com/SocketDev/socket-wheelhouse/tree/main/template/.claude/hooks/token-guard)
 and are required to be byte-identical across every fleet repo.
 `scripts/sync-scaffolding.mts` flags drift; `--fix` rewrites it.
 

--- a/.claude/skills/_shared/path-guard-rule.md
+++ b/.claude/skills/_shared/path-guard-rule.md
@@ -1,6 +1,6 @@
 <!--
 Shared snippet — the canonical "1 path, 1 reference" rule text.
-Synced byte-identical across the Socket fleet via socket-repo-template's
+Synced byte-identical across the Socket fleet via socket-wheelhouse's
 sync-scaffolding.mts (SHARED_SKILL_FILES).
 
 This file is the source of truth for the rule's wording. Three artifacts
@@ -11,7 +11,7 @@ embed (or paraphrase) it:
   3. .claude/skills/guarding-paths/SKILL.md — what the skill enforces.
 
 If the wording changes here, re-run `node scripts/sync-scaffolding.mts
---all --fix` from socket-repo-template to propagate.
+--all --fix` from socket-wheelhouse to propagate.
 -->
 
 ## 1 path, 1 reference

--- a/.claude/skills/_shared/skill-authoring.md
+++ b/.claude/skills/_shared/skill-authoring.md
@@ -89,7 +89,7 @@ The Anthropic docs codify several rules; honor them:
 
 ## Fleet repo references
 
-When scaffolding a new fleet repo, or when a sync question arises ("how does the fleet do X?"), mimic the reference that matches both axes (`layout` + `native`) in `.config/socket-repo-template.json`:
+When scaffolding a new fleet repo, or when a sync question arises ("how does the fleet do X?"), mimic the reference that matches both axes (`layout` + `native`) in `.config/socket-wheelhouse.json`:
 
 | layout × native | Best reference | Notes |
 |---|---|---|

--- a/.claude/skills/driving-cursor-bugbot/SKILL.md
+++ b/.claude/skills/driving-cursor-bugbot/SKILL.md
@@ -36,7 +36,7 @@ This skill makes all of the above mechanical.
 |---|---|---|
 | 1 | Inventory | List Bugbot findings via `gh api .../pulls/<PR#>/comments`. Capture `id`, `path`, `line`, body. |
 | 2 | Classify | Sort each finding into `real` / `already-fixed` / `false-positive` / `wont-fix`. |
-| 3 | Fix | Implement fixes for `real` findings. Propagate to canonical (`socket-repo-template/template/`) when the file is fleet-shared. One commit per finding. |
+| 3 | Fix | Implement fixes for `real` findings. Propagate to canonical (`socket-wheelhouse/template/`) when the file is fleet-shared. One commit per finding. |
 | 4 | Reply + resolve | Reply on each inline thread (NOT detached); resolve on `fixed` / `already-fixed` / `false-positive`; leave `wont-fix` open. |
 | 5 | Title + body realignment | Per CLAUDE.md, update PR title / body when scope shifted. Use `gh pr edit`. |
 | 6 | Push | `git push`. Bugbot re-reviews; loop back to phase 1 if new findings. |
@@ -60,7 +60,7 @@ To check `already-fixed`: read `git log` on the PR branch since the comment's `c
 - **Reply first, resolve second.** Resolving without a written reply leaves future readers blind.
 - **One commit per `real` finding.** Don't bundle. Conventional Commits: `fix(<scope>): address Bugbot finding on <file>:<line>`.
 - **Push after each fix; reply with the new commit SHA.** The reply cites the SHA, so the SHA must already be pushed.
-- **Propagate canonical fixes.** When the file lives under `.claude/hooks/`, `.claude/skills/`, or `.git-hooks/`, fix at `socket-repo-template/template/` first, then sync to consumers — drifting fleet copies is the larger bug.
+- **Propagate canonical fixes.** When the file lives under `.claude/hooks/`, `.claude/skills/`, or `.git-hooks/`, fix at `socket-wheelhouse/template/` first, then sync to consumers — drifting fleet copies is the larger bug.
 
 ## When to use
 

--- a/.claude/skills/driving-cursor-bugbot/reference.md
+++ b/.claude/skills/driving-cursor-bugbot/reference.md
@@ -76,7 +76,7 @@ mutation($threadId: ID!) {
 Keep replies short. Bugbot doesn't read them, but the human reviewer does.
 
 - **Real, fixed**: `Fixed in <commit-sha>. <one-sentence what changed>. <propagation note if any>.`
-  - Example: `Fixed in a63d29105. Restored the Linear team-key + linear.app URL blocking from the deleted .sh hook as scanLinearRefs() in _helpers.mts. Synced from canonical socket-repo-template.`
+  - Example: `Fixed in a63d29105. Restored the Linear team-key + linear.app URL blocking from the deleted .sh hook as scanLinearRefs() in _helpers.mts. Synced from canonical socket-wheelhouse.`
 
 - **Already fixed**: `Already fixed in <commit-sha> (current PR HEAD). <one-sentence what changed>.`
 

--- a/.config/rolldown/lib-stub.mts
+++ b/.config/rolldown/lib-stub.mts
@@ -16,7 +16,7 @@
  *
  * Source: lifted from socket-packageurl-js's inline plugin
  * (.config/rolldown.config.mts), generalized so the stub-pattern is
- * caller-provided. Fleet-canonical via socket-repo-template.
+ * caller-provided. Fleet-canonical via socket-wheelhouse.
  */
 
 import type { Plugin } from 'rolldown'

--- a/.config/socket-wheelhouse-schema.json
+++ b/.config/socket-wheelhouse-schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/SocketDev/socket-repo-template-schema.json",
-  "title": "socket-repo-template per-repo config",
-  "description": "Per-repo socket-repo-template config. Two valid locations: `.config/socket-repo-template.json` (primary) or `.socket-repo-template.json` at the repo root (alternative). Both are first-class — pick the location that fits your repo's convention.",
+  "$id": "https://github.com/SocketDev/socket-wheelhouse-schema.json",
+  "title": "socket-wheelhouse per-repo config",
+  "description": "Per-repo socket-wheelhouse config. Two valid locations: `.config/socket-wheelhouse.json` (primary) or `.socket-wheelhouse.json` at the repo root (alternative). Both are first-class — pick the location that fits your repo's convention.",
   "type": "object",
   "required": ["schemaVersion", "repoName", "layout", "native"],
   "properties": {
     "$schema": {
-      "description": "JSON Schema reference for editor autocompletion. Conventionally `./socket-repo-template-schema.json` — both the config and its schema live side-by-side in `.config/`.",
+      "description": "JSON Schema reference for editor autocompletion. Conventionally `./socket-wheelhouse-schema.json` — both the config and its schema live side-by-side in `.config/`.",
       "type": "string"
     },
     "schemaVersion": {

--- a/.config/socket-wheelhouse.json
+++ b/.config/socket-wheelhouse.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./socket-repo-template-schema.json",
+  "$schema": "./socket-wheelhouse-schema.json",
   "schemaVersion": 1,
   "repoName": "socket-registry",
   "layout": "monorepo",

--- a/.git-hooks/_helpers.mts
+++ b/.git-hooks/_helpers.mts
@@ -485,7 +485,7 @@ const FLEET_REPO_NAMES = [
   'socket-lib',
   'socket-packageurl-js',
   'socket-registry',
-  'socket-repo-template',
+  'socket-wheelhouse',
   'socket-sdk-js',
   'socket-sdxgen',
   'socket-stuie',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **MANDATORY**: Act as principal-level engineer. Follow these guidelines exactly.
 
-<!-- BEGIN FLEET-CANONICAL — sync via socket-repo-template/scripts/sync-scaffolding.mts. Do not edit downstream. -->
+<!-- BEGIN FLEET-CANONICAL — sync via socket-wheelhouse/scripts/sync-scaffolding.mts. Do not edit downstream. -->
 
 ## 📚 Fleet Standards
 
@@ -171,14 +171,14 @@ How to check:
 
 1. If you're editing one of these in repo A, grep the same thing in repos B/C/D. If A is older, bump A first; if A is newer, plan a sync to B/C/D.
 2. `socket-registry`'s `setup-and-install` action is the canonical source for tool SHAs. Diverging from it is drift.
-3. `socket-repo-template`'s `template/` tree is the canonical source for `.claude/`, CLAUDE.md fleet block, and hook code. Diverging is drift.
+3. `socket-wheelhouse`'s `template/` tree is the canonical source for `.claude/`, CLAUDE.md fleet block, and hook code. Diverging is drift.
 4. Run `pnpm run sync-scaffolding` (in repos that have it) to surface drift programmatically.
 
 Never silently let drift sit. Either reconcile in the same PR or open a follow-up PR titled `chore(sync): cascade <thing> from <newer-repo>` and link it.
 
 ### Never fork fleet-canonical files locally
 
-🚨 Edit fleet-canonical files (anything in the sync manifest) ONLY in `socket-repo-template/template/...` — never in a downstream repo. Spot a missing helper in a downstream copy? Lift it upstream and re-cascade. Enforced by `.claude/hooks/no-fleet-fork-guard/`; bypass: `Allow fleet-fork bypass`. Full canonical-surface list + lifting workflow: [`docs/claude.md/no-local-fork-canonical.md`](docs/claude.md/no-local-fork-canonical.md).
+🚨 Edit fleet-canonical files (anything in the sync manifest) ONLY in `socket-wheelhouse/template/...` — never in a downstream repo. Spot a missing helper in a downstream copy? Lift it upstream and re-cascade. Enforced by `.claude/hooks/no-fleet-fork-guard/`; bypass: `Allow fleet-fork bypass`. Full canonical-surface list + lifting workflow: [`docs/claude.md/no-local-fork-canonical.md`](docs/claude.md/no-local-fork-canonical.md).
 
 ### Code style
 
@@ -291,11 +291,11 @@ Full hook spec in [`.claude/hooks/token-guard/README.md`](.claude/hooks/token-gu
 
 Every skill under `.claude/skills/` falls into one of three tiers — surface this distinction when adding a new skill so it lands in the right place:
 
-- **Fleet skill** — present in every fleet repo, identical contract everywhere. Examples: `guarding-paths`, `scanning-quality`, `scanning-security`, `updating`, `locking-down-programmatic-claude`, `plug-leaking-promise-race`. New fleet skills land in `socket-repo-template/template/.claude/skills/<name>/` and cascade via `node socket-repo-template/scripts/sync-scaffolding.mts --all --fix`. Track them in `SHARED_SKILL_FILES` in the sync manifest.
+- **Fleet skill** — present in every fleet repo, identical contract everywhere. Examples: `guarding-paths`, `scanning-quality`, `scanning-security`, `updating`, `locking-down-programmatic-claude`, `plug-leaking-promise-race`. New fleet skills land in `socket-wheelhouse/template/.claude/skills/<name>/` and cascade via `node socket-wheelhouse/scripts/sync-scaffolding.mts --all --fix`. Track them in `SHARED_SKILL_FILES` in the sync manifest.
 - **Partial skill** — present in the subset of repos that need it, identical contract within that subset. Examples: `driving-cursor-bugbot` (every repo with PR review), `updating-lockstep` (every repo with `lockstep.json`), `squashing-history` (repos with the squash workflow). Live in each adopting repo's `.claude/skills/<name>/`. When you change one, propagate to the others.
 - **Unique skill** — one repo only, bespoke to that repo's domain. Examples: `updating-cdxgen` (sdxgen), `updating-yoga` (socket-btm), `release` (socket-registry). Never canonical-tracked; the host repo owns it end-to-end.
 
-Audit the current classification with `node socket-repo-template/scripts/run-skill-fleet.mts --list-skills`.
+Audit the current classification with `node socket-wheelhouse/scripts/run-skill-fleet.mts --list-skills`.
 
 #### `updating` umbrella + `updating-*` siblings
 
@@ -303,7 +303,7 @@ Audit the current classification with `node socket-repo-template/scripts/run-ski
 
 #### Running skills across the fleet
 
-`scripts/run-skill-fleet.mts` (in `socket-repo-template`) spawns one headless `claude --print` agent per fleet repo, in parallel (concurrency 4 by default), with the four lockdown flags set per the _Programmatic Claude calls_ rule above. Per-skill profile table maps known skills to sensible tool/allow/disallow lists; override with `--tools` / `--allow` / `--disallow`. Per-repo logs land in `.cache/fleet-skill/<timestamp>-<skill>/<repo>.log`. Use `Promise.allSettled` semantics — one repo's failure doesn't abort the rest.
+`scripts/run-skill-fleet.mts` (in `socket-wheelhouse`) spawns one headless `claude --print` agent per fleet repo, in parallel (concurrency 4 by default), with the four lockdown flags set per the _Programmatic Claude calls_ rule above. Per-skill profile table maps known skills to sensible tool/allow/disallow lists; override with `--tools` / `--allow` / `--disallow`. Per-repo logs land in `.cache/fleet-skill/<timestamp>-<skill>/<repo>.log`. Use `Promise.allSettled` semantics — one repo's failure doesn't abort the rest.
 
 ```bash
 pnpm run fleet-skill updating                       # update every fleet repo

--- a/docs/claude.md/bypass-phrases.md
+++ b/docs/claude.md/bypass-phrases.md
@@ -46,4 +46,4 @@ When introducing a new destructive flag or hook bypass:
 1. Add a new entry to the `CHECKS` array in `.claude/hooks/no-revert-guard/index.mts`. Each check is `{ pattern: RegExp, bypassPhrase: string, label: string }`.
 2. Add a row to this reference's table.
 3. Add a test case to `.claude/hooks/no-revert-guard/test/index.test.mts` covering both the blocked-without-phrase and allowed-with-phrase paths.
-4. Cascade via `node socket-repo-template/scripts/sync-scaffolding.mts --all --fix` so every fleet repo picks up the change.
+4. Cascade via `node socket-wheelhouse/scripts/sync-scaffolding.mts --all --fix` so every fleet repo picks up the change.

--- a/docs/claude.md/no-local-fork-canonical.md
+++ b/docs/claude.md/no-local-fork-canonical.md
@@ -1,6 +1,6 @@
 # Never fork fleet-canonical files locally
 
-Fleet-canonical files (anything tracked by `socket-repo-template/scripts/sync-scaffolding/manifest.mts`) MUST be edited in `socket-repo-template/template/...` and cascaded out — never branched locally in a downstream fleet repo.
+Fleet-canonical files (anything tracked by `socket-wheelhouse/scripts/sync-scaffolding/manifest.mts`) MUST be edited in `socket-wheelhouse/template/...` and cascaded out — never branched locally in a downstream fleet repo.
 
 ## Canonical surfaces
 
@@ -15,13 +15,13 @@ These directories and files cascade fleet-wide. They are **not** repo-local:
 - `.husky/` — Husky entry shims
 - Anything else listed in the sync manifest
 
-If unsure, check `socket-repo-template/scripts/sync-scaffolding/manifest.mts`. Tracked = canonical.
+If unsure, check `socket-wheelhouse/scripts/sync-scaffolding/manifest.mts`. Tracked = canonical.
 
 ## How to apply
 
 If a downstream repo needs a behavior change in one of these files:
 
-1. Edit the file in `socket-repo-template/template/...`.
+1. Edit the file in `socket-wheelhouse/template/...`.
 2. Commit the template change.
 3. Run `node scripts/sync-scaffolding/main.mts --target <downstream-repo> --fix` to cascade.
 

--- a/scripts/lockstep-schema.mts
+++ b/scripts/lockstep-schema.mts
@@ -10,7 +10,7 @@
  *     `@socketsecurity/lib/validation/validate-schema`
  *
  * Byte-identical across sdxgen / socket-btm / socket-registry /
- * socket-repo-template / stuie / ultrathink via sync-scaffolding.mts.
+ * socket-wheelhouse / stuie / ultrathink via sync-scaffolding.mts.
  */
 
 import { Type, type Static } from '@sinclair/typebox'

--- a/scripts/lockstep.mts
+++ b/scripts/lockstep.mts
@@ -1,6 +1,6 @@
 /**
  * @fileoverview lockstep harness (canonical; mirrored in
- * socket-repo-template/template/scripts/lockstep.mts).
+ * socket-wheelhouse/template/scripts/lockstep.mts).
  *
  * Reads `lockstep.json` (+ any `includes[]` sub-manifests) and validates each
  * row against its upstream or sibling ports. Every supported `kind` has a

--- a/scripts/power-state.mts
+++ b/scripts/power-state.mts
@@ -26,7 +26,7 @@
  * Returns a Promise so callers don't block the event loop on shellout
  * paths.
  *
- * Byte-identical across the fleet via socket-repo-template's
+ * Byte-identical across the fleet via socket-wheelhouse's
  * sync-scaffolding (IDENTICAL_FILES).
  */
 

--- a/scripts/socket-wheelhouse-emit-schema.mts
+++ b/scripts/socket-wheelhouse-emit-schema.mts
@@ -1,8 +1,8 @@
 /**
- * @fileoverview Emit `socket-repo-template-schema.json` from the
+ * @fileoverview Emit `socket-wheelhouse-schema.json` from the
  * TypeBox source.
  *
- * Run via `pnpm run socket-repo-template:emit-schema` from a fleet
+ * Run via `pnpm run socket-wheelhouse:emit-schema` from a fleet
  * repo (the worktree where TypeBox is installed). Mirrors the lockstep
  * emit pattern.
  */
@@ -14,25 +14,25 @@ import { fileURLToPath } from 'node:url'
 import { spawn } from '@socketsecurity/lib/spawn'
 import { getDefaultLogger } from '@socketsecurity/lib/logger'
 
-import { SocketRepoTemplateConfigSchema } from './socket-repo-template-schema.mts'
+import { SocketRepoTemplateConfigSchema } from './socket-wheelhouse-schema.mts'
 
 const logger = getDefaultLogger()
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(__dirname, '..')
 // Schema lives in `.config/` next to the per-repo
-// `.config/socket-repo-template.json` it describes — the marker's
-// `$schema` ref is `./socket-repo-template-schema.json`.
+// `.config/socket-wheelhouse.json` it describes — the marker's
+// `$schema` ref is `./socket-wheelhouse-schema.json`.
 const outPath = path.join(
   rootDir,
   '.config',
-  'socket-repo-template-schema.json',
+  'socket-wheelhouse-schema.json',
 )
 
 const enriched = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://github.com/SocketDev/socket-repo-template-schema.json',
-  title: 'socket-repo-template per-repo config',
+  $id: 'https://github.com/SocketDev/socket-wheelhouse-schema.json',
+  title: 'socket-wheelhouse per-repo config',
   ...SocketRepoTemplateConfigSchema,
 }
 

--- a/scripts/socket-wheelhouse-schema.mts
+++ b/scripts/socket-wheelhouse-schema.mts
@@ -1,8 +1,8 @@
 /**
- * @fileoverview TypeBox schema for the per-fleet-repo socket-repo-template
+ * @fileoverview TypeBox schema for the per-fleet-repo socket-wheelhouse
  * config consumed by `sync-scaffolding`. Two valid locations:
- * `.config/socket-repo-template.json` (primary) or
- * `.socket-repo-template.json` at the repo root (alternative). Both are
+ * `.config/socket-wheelhouse.json` (primary) or
+ * `.socket-wheelhouse.json` at the repo root (alternative). Both are
  * first-class — pick the location that fits your repo's convention.
  *
  * Each fleet repo (socket-lib, socket-cli, ultrathink, …) ships this
@@ -13,8 +13,8 @@
  * Source-of-truth flow:
  *   - This TypeBox source → `Static<typeof SocketRepoTemplateConfigSchema>`
  *     for typed reads in the runner.
- *   - `socket-repo-template-emit-schema.mts` writes
- *     `.config/socket-repo-template-schema.json` (draft 2020-12) next to
+ *   - `socket-wheelhouse-emit-schema.mts` writes
+ *     `.config/socket-wheelhouse-schema.json` (draft 2020-12) next to
  *     the per-repo config.
  *   - The per-repo config references the JSON Schema via its `$schema`
  *     field for IDE autocompletion.
@@ -249,7 +249,7 @@ export const SocketRepoTemplateConfigSchema = Type.Object(
     $schema: Type.Optional(
       Type.String({
         description:
-          'JSON Schema reference for editor autocompletion. Conventionally `./socket-repo-template-schema.json` — both the config and its schema live side-by-side in `.config/`.',
+          'JSON Schema reference for editor autocompletion. Conventionally `./socket-wheelhouse-schema.json` — both the config and its schema live side-by-side in `.config/`.',
       }),
     ),
     schemaVersion: Type.Literal(1, {
@@ -272,7 +272,7 @@ export const SocketRepoTemplateConfigSchema = Type.Object(
   },
   {
     description:
-      "Per-repo socket-repo-template config. Two valid locations: `.config/socket-repo-template.json` (primary) or `.socket-repo-template.json` at the repo root (alternative). Both are first-class — pick the location that fits your repo's convention.",
+      "Per-repo socket-wheelhouse config. Two valid locations: `.config/socket-wheelhouse.json` (primary) or `.socket-wheelhouse.json` at the repo root (alternative). Both are first-class — pick the location that fits your repo's convention.",
   },
 )
 


### PR DESCRIPTION
## Summary
- Renames `.config/socket-repo-template.json` → `.config/socket-wheelhouse.json` (and matching `*-schema.json` / `*-schema.mts` / `*-emit-schema.mts`).
- Updates every cross-reference to `socket-repo-template` → `socket-wheelhouse`.
- Matches the canonical rename in `SocketDev/socket-wheelhouse` (formerly `socket-repo-template`).

## Test plan
- [ ] `pnpm run check` passes
- [ ] `pnpm install` is happy (workspace config files still resolve)