### PR TITLE
fix(setup): also bootstrap @socketsecurity/lib-stable

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -513,9 +513,10 @@ runs:
         # root scripts can import them at module-load time. Order
         # matters only for log readability.
         PACKAGES=(
-          '@socketsecurity/lib'
           '@socketregistry/packageurl-js'
           '@sinclair/typebox'
+          '@socketsecurity/lib'
+          '@socketsecurity/lib-stable'
         )
         for PKG in "${PACKAGES[@]}"; do
           # Already resolvable? Skip.


### PR DESCRIPTION
## Summary

The setup composite action pre-seeds zero-dep packages into `node_modules/` so root scripts + `.claude/hooks/*` can import them at module-load time without waiting for `pnpm install`. The pre-seed list included `@socketsecurity/lib` but **not** the alias name `@socketsecurity/lib-stable` that many fleet repos pin via:

```yaml
overrides:
  '@socketsecurity/lib-stable': npm:@socketsecurity/lib@6.0.5
```

This fix appends `@socketsecurity/lib-stable` to the `PACKAGES` array. The existing `read-pinned-version.mts` helper already resolves the alias (`npm:@target@ver`) and the install loop already writes to `node_modules/<PKG>/` using the alias *name*, so the entire fix is one new line.

Also sorted the array alphanumerically per the fleet sort convention.

## Why it surfaces now

While dispatching socket-btm/stubs.yml, the `verify upstream publishes are fresh` preflight job consistently fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@socketsecurity/lib-stable'
  imported from .../scripts/check-publish-prereq.mts
```

The workflow deliberately skips pnpm install (5-min job, runs a single Node script) and relies on setup to pre-seed everything the script imports. `check-publish-prereq.mts` imports `@socketsecurity/lib-stable/logger/default` + `@socketsecurity/lib-stable/process/spawn/child` — both valid fleet imports per the socket/prefer-stable-self-import rule, but unresolvable without this bootstrap addition.

## Test plan

- [ ] After merge, dispatch socket-btm/stubs.yml with -f dry-run=true — preflight should resolve @socketsecurity/lib-stable and proceed to the matrix build.
- [ ] No regressions on other fleet repos (additive change; existing @socketsecurity/lib install path unchanged).