### PR TITLE
chore(ci): bump socket-registry action refs to main (dd46ee5c)

### DIFF
--- a/.github/actions/setup-and-install/action.yml
+++ b/.github/actions/setup-and-install/action.yml
@@ -77,14 +77,14 @@ runs:
   steps:
     - name: Checkout
       if: inputs.checkout == 'true'
-      uses: SocketDev/socket-registry/.github/actions/checkout@3d33ecebb1d3cdba3529c843a9f0954fd6384702 # main (2026-05-28)
+      uses: SocketDev/socket-registry/.github/actions/checkout@dd46ee5cbe07a46b4d44fbb96d956400654ccf24 # main (2026-06-01)
       with:
         fetch-depth: ${{ inputs.checkout-fetch-depth }}
         ref: ${{ inputs.checkout-ref }}
         working-directory: ${{ inputs.working-directory }}
 
     - name: Setup environment
-      uses: SocketDev/socket-registry/.github/actions/setup@af6b289bfb1b6a940e89cb418efe75edfcf43693 # main (2026-05-28)
+      uses: SocketDev/socket-registry/.github/actions/setup@dd46ee5cbe07a46b4d44fbb96d956400654ccf24 # main (2026-06-01)
       with:
         debug: ${{ inputs.debug }}
         node-version: ${{ inputs.node-version }}
@@ -94,12 +94,12 @@ runs:
         working-directory: ${{ inputs.working-directory }}
 
     - name: Install dependencies
-      uses: SocketDev/socket-registry/.github/actions/install@3d33ecebb1d3cdba3529c843a9f0954fd6384702 # main (2026-05-28)
+      uses: SocketDev/socket-registry/.github/actions/install@dd46ee5cbe07a46b4d44fbb96d956400654ccf24 # main (2026-06-01)
       with:
         working-directory: ${{ inputs.working-directory }}
 
     - name: Setup Go toolchain
       if: inputs.setup-go == 'true'
-      uses: SocketDev/socket-registry/.github/actions/setup-go-toolchain@3d33ecebb1d3cdba3529c843a9f0954fd6384702 # main (2026-05-28)
+      uses: SocketDev/socket-registry/.github/actions/setup-go-toolchain@dd46ee5cbe07a46b4d44fbb96d956400654ccf24 # main (2026-06-01)
       with:
         version: ${{ inputs.setup-go-version }}


### PR DESCRIPTION
## Summary

Layer 2a cascade for SFW v1.12.0 (#bumped at dd46ee5c). Re-pins `setup-and-install/action.yml`'s internal Layer 1 / 2a refs to the SFW merge commit so transitive `external-tools.json` reads pick up the new SFW pin.

## Test plan
- [x] No stale refs in `.github/actions/setup-and-install/`
- [x] No third-party `actions/*` SHAs were touched