### PR TITLE
chore(ci): bump socket-registry action refs to main (66611664)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.check-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ inputs.check-node-version }}
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.lint-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ inputs.lint-node-version }}
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.type-check-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ inputs.type-check-node-version }}
@@ -241,7 +241,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ inputs.test-timeout-minutes }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           debug: ${{ inputs.debug }}
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -148,7 +148,7 @@ jobs:
             exit 1
           fi
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           checkout-ref: ${{ inputs.ref }}
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -135,7 +135,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           socket-api-token: ${{ secrets.SOCKET_API_TOKEN || secrets.SOCKET_API_KEY }}
 
@@ -185,7 +185,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@2fa6f4242bb97ed599cb07d3ee13b2239be4f87c # main (2026-05-28)
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@66611664a95d469f4fc11ae079ee6acfcd61c674 # main (2026-06-01)
         with:
           checkout-fetch-depth: ${{ inputs.checkout-fetch-depth }}
           socket-api-token: ${{ secrets.SOCKET_API_TOKEN || secrets.SOCKET_API_KEY }}


### PR DESCRIPTION
## Summary

Layer 3 cascade for SFW v1.12.0. Re-pins `setup-and-install` references in `ci.yml`, `provenance.yml`, and `weekly-update.yml` to the Layer 2b merge SHA (#288) so the reusable workflows pick up the SFW v1.12.0 transitive update.

## Test plan
- [x] No stale `setup-and-install@` refs remain
- [x] Third-party SHAs untouched