### PR TITLE
refactor(scripts): inline Socket-override check in update-manifest

### DIFF
--- a/scripts/npm/update-manifest.mts
+++ b/scripts/npm/update-manifest.mts
@@ -20,7 +20,6 @@ import { biomeFormat } from '../repo/util/biome.mts'
 import { getModifiedFiles } from '../repo/util/git.mts'
 import { fetchPackageManifest } from '@socketsecurity/lib-stable/packages/manifest'
 import { resolveOriginalPackageName } from '@socketsecurity/lib-stable/packages/normalize'
-import { isBlessedPackageName } from '@socketsecurity/lib-stable/packages/validation'
 import { resolvePackageJsonEntryExports } from '@socketsecurity/lib-stable/packages/exports'
 import { readPackageJson } from '@socketsecurity/lib-stable/packages/read'
 import { extractPackage } from '@socketsecurity/lib-stable/packages/tarball'
@@ -85,7 +84,10 @@ export async function addNpmManifestData(manifest, options) {
       await extractPackage(nmPkgId, async nmPkgPath => {
         nmPkgJson = await readPackageJson(nmPkgPath, { normalize: true })
       })
-      const isBlessed = isBlessedPackageName(data.name)
+      // Socket-maintained overrides take engines from the published
+      // package.json; third-party extensions keep the manifest's engines.
+      // (Inlined from the retired isBlessedPackageName helper.)
+      const isSocketOverride = data.name.startsWith('@socketregistry/')
       manifestData.push([
         PackageURL.fromString(
           `pkg:${eco}/${data.name}@${nmPkgJson.version}`,
@@ -93,7 +95,9 @@ export async function addNpmManifestData(manifest, options) {
         {
           categories: nmPkgJson.socket?.categories ?? data.categories,
           engines: filterEngines(
-            isBlessed ? (nmPkgJson.engines ?? data.engines) : data.engines,
+            isSocketOverride
+              ? (nmPkgJson.engines ?? data.engines)
+              : data.engines,
           ),
           interop: data.interop,
           license: nmPkgJson.license ?? data.license,


### PR DESCRIPTION
`isBlessedPackageName` is being retired from `@socketsecurity/lib` as part of removing special treatment for Socket's own packages (the server-side score blessing is being removed in parallel). This script was the last importer of the published helper.

The engines-source decision here only needs "is this a Socket-maintained `@socketregistry/*` override vs a third-party extension", so that narrower check is inlined. Verified against `registry/extensions.json`: the split is unchanged for every current entry (`@socketregistry/packageurl-js` → engines from published package.json; `shell-quote` → engines from manifest data).

Unblocks deleting the helper from socket-lib.